### PR TITLE
[WIP] v2 smart-contract-integration / quick-start.md improvements

### DIFF
--- a/docs/V2/guides/smart-contract-integration/01-quick-start.md
+++ b/docs/V2/guides/smart-contract-integration/01-quick-start.md
@@ -22,8 +22,7 @@ To follow this guide, you must have the following installed:
 The easiest way to follow this tutorial, is to bootstrap the boilerplate with [hardhat](https://hardhat.org/getting-started/).
 
 ```shell script
-mkdir demo
-cd demo
+mkdir demo && cd "$_"
 npx hardhat
 ```
 

--- a/docs/V2/guides/smart-contract-integration/01-quick-start.md
+++ b/docs/V2/guides/smart-contract-integration/01-quick-start.md
@@ -21,7 +21,7 @@ To follow this guide, you must have the following installed:
 
 The easiest way to follow this tutorial, is to bootstrap the boilerplate with [hardhat](https://hardhat.org/getting-started/).
 
-```shell script
+```shell-script
 mkdir demo && cd "$_"
 npx hardhat
 ```
@@ -53,14 +53,14 @@ Let's add both the
 [`@uniswap/v2-core`](https://www.npmjs.com/package/@uniswap/v2-core) and
 [`@uniswap/v2-periphery`](https://www.npmjs.com/package/@uniswap/v2-periphery) packages.
 
-```shell script
+```shell-script
 npm i --save @uniswap/v2-core
 npm i --save @uniswap/v2-periphery
 ```
 
 If you check the `node_modules/@uniswap` directory, you can now find the Uniswap V2 contracts.
 
-```shell script
+```shell-script
 >ls node_modules/@uniswap/v2-core/contracts
 UniswapV2ERC20.sol    UniswapV2Pair.sol     libraries/
 UniswapV2Factory.sol  interfaces/           test/
@@ -81,7 +81,7 @@ For writing Solidity, we recommend IntelliJ or VSCode with a solidity plugin, bu
 Let's write a contract that returns the value of some amount of liquidity shares for a given token pair.
 First create a couple of files:
 
-```shell script
+```shell-script
 mkdir contracts/interfaces
 touch contracts/interfaces/ILiquidityValueCalculator.sol
 touch contracts/LiquidityValueCalculator.sol
@@ -242,7 +242,7 @@ main()
 
 To deploy the contracts to the local chain, simply run
 
-```shell script
+```shell-script
 npm run deploy
 ```
 

--- a/docs/V2/guides/smart-contract-integration/01-quick-start.md
+++ b/docs/V2/guides/smart-contract-integration/01-quick-start.md
@@ -5,7 +5,7 @@ tags: smart contract integration, documentation, quick start
 slug: /guides/
 ---
 
-Developing smart contracts for Ethereum involves a bevy of off-chain tools used for producing and testing bytecode 
+Developing smart contracts for Ethereum involves a bevy of off-chain tools used for producing and testing bytecode
 that runs on the [Ethereum Virtual Machine (EVM)](https://eth.wiki/en/concepts/evm/ethereum-virtual-machine-(evm)-awesome-list).
 Some tools also include workflows for deploying this bytecode to the Ethereum network and testnets.
 There are many options for these tools. This guide walks you through writing and testing a simple smart contract that
@@ -19,8 +19,8 @@ To follow this guide, you must have the following installed:
 
 ## Bootstrapping a project
 
-You can start from scratch, but it's easier to use a tool like `truffle` to bootstrap an empty project. 
-Create an empty directory and run `npx truffle init` inside that directory to unbox the default 
+You can start from scratch, but it's easier to use a tool like `truffle` to bootstrap an empty project.
+Create an empty directory and run `npx truffle init` inside that directory to unbox the default
 [Truffle box](https://www.trufflesuite.com/boxes).
 
 ```shell script
@@ -32,7 +32,7 @@ npx truffle init
 ## Setting up npm
 
 In order to reference the Uniswap V2 contracts, you should use the npm artifacts we deploy containing the core and
-periphery smart contracts and interfaces. To add npm dependencies, we first initialize the npm package. 
+periphery smart contracts and interfaces. To add npm dependencies, we first initialize the npm package.
 We can run `npm init` in the same directory to create a `package.json` file. You can accept all the defaults and
 change it later.
 
@@ -42,8 +42,8 @@ npm init
 
 ## Adding dependencies
 
-Now that we have an npm package, we can add our dependencies. Let's add both the 
-[`@uniswap/v2-core`](https://www.npmjs.com/package/@uniswap/v2-core) and 
+Now that we have an npm package, we can add our dependencies. Let's add both the
+[`@uniswap/v2-core`](https://www.npmjs.com/package/@uniswap/v2-core) and
 [`@uniswap/v2-periphery`](https://www.npmjs.com/package/@uniswap/v2-periphery) packages.
 
 ```shell script
@@ -51,7 +51,7 @@ npm i --save @uniswap/v2-core
 npm i --save @uniswap/v2-periphery
 ```
 
-If you check the `node_modules/@uniswap` directory, you can now find the Uniswap V2 contracts. 
+If you check the `node_modules/@uniswap` directory, you can now find the Uniswap V2 contracts.
 
 ```shell script
 moody@MacBook-Pro ~/I/u/demo> ls node_modules/@uniswap/v2-core/contracts
@@ -67,16 +67,16 @@ These packages include both the smart contract source code and the build artifac
 
 ## Writing our contract
 
-We can now get started writing our example contract. 
+We can now get started writing our example contract.
 For writing Solidity, we recommend IntelliJ or VSCode with a solidity plugin, but you can use any text editor.
-Let's write a contract that returns the value of some amount of liquidity shares for a given token pair. 
+Let's write a contract that returns the value of some amount of liquidity shares for a given token pair.
 First create a couple of files:
 
 ```shell script
 mkdir contracts/interfaces
 touch contracts/interfaces/ILiquidityValueCalculator.sol
 touch contracts/LiquidityValueCalculator.sol
-``` 
+```
 
 This will be the interface of the contract we implement. Put it in `contracts/interfaces/ILiquidityValueCalculator.sol`.
 
@@ -89,7 +89,7 @@ interface ILiquidityValueCalculator {
 ```
 
 Now let's start with the constructor. You need to know where the `UniswapV2Factory` is deployed in order to compute the
-address of the pair and look up the total supply of liquidity shares, plus the amounts for the reserves. 
+address of the pair and look up the total supply of liquidity shares, plus the amounts for the reserves.
 We can store this as an address passed to the constructor.
 
 The factory address is constant on mainnet and all testnets, so it may be tempting to make this value a constant in your contract,
@@ -109,13 +109,13 @@ contract LiquidityValueCalculator is ILiquidityValueCalculator {
 }
 ```
 
-Now we need to be able to look up the total supply of liquidity for a pair, and its token balances. 
+Now we need to be able to look up the total supply of liquidity for a pair, and its token balances.
 Let's put this in a separate function. To implement it, we must:
 
 1. Look up the pair address
 2. Get the reserves of the pair
 3. Get the total supply of the pair liquidity
-4. Sort the reserves in the order of tokenA, tokenB 
+4. Sort the reserves in the order of tokenA, tokenB
 
 The [`UniswapV2Library`](/docs/v2/smart-contracts/library/) has some helpful methods for this.
 
@@ -162,7 +162,7 @@ contract LiquidityValueCalculator is ILiquidityValueCalculator {
         revert('TODO');
     }
 }
-``` 
+```
 
 ## Writing tests
 
@@ -178,7 +178,7 @@ In order to test your contract, you need to:
 
 \#1 is handled for you automatically by the `truffle test` command.
 
-Note you should only deploy the precompiled Uniswap contracts in the `build` directories for unit tests. 
+Note you should only deploy the precompiled Uniswap contracts in the `build` directories for unit tests.
 This is because solidity appends a metadata hash to compiled contract artifacts which includes the hash of the contract
 source code path, and compilations on other machines will not result in the exact same bytecode.
 This is problematic because in Uniswap V2 we use the hash of the bytecode in the v2-periphery
@@ -193,12 +193,12 @@ const UniswapV2FactoryBytecode = require('@uniswap/v2-core/build/UniswapV2Factor
 
 We recommend using a standard ERC20 from `@openzeppelin/contracts` for deploying an ERC20.
 
-You can read more about deploying contracts and writing tests using Truffle 
+You can read more about deploying contracts and writing tests using Truffle
 [here](https://www.trufflesuite.com/docs/truffle/testing/writing-tests-in-javascript).
 
 ## Compiling and deploying the contract
 
-Learn more about compiling and deploying contracts using Truffle 
+Learn more about compiling and deploying contracts using Truffle
 [here](https://www.trufflesuite.com/docs/truffle/getting-started/compiling-contracts) and
 [here](https://www.trufflesuite.com/docs/truffle/getting-started/running-migrations) respectively.
 

--- a/docs/V2/guides/smart-contract-integration/01-quick-start.md
+++ b/docs/V2/guides/smart-contract-integration/01-quick-start.md
@@ -81,7 +81,7 @@ touch contracts/LiquidityValueCalculator.sol
 This will be the interface of the contract we implement. Put it in `contracts/interfaces/ILiquidityValueCalculator.sol`.
 
 ```solidity
-pragma solidity ^0.6.6;
+pragma solidity =0.6.6;
 
 interface ILiquidityValueCalculator {
     function computeLiquidityShareValue(uint liquidity, address tokenA, address tokenB) external returns (uint tokenAAmount, uint tokenBAmount);
@@ -97,7 +97,7 @@ but since we need to unit test the contract it should be an argument. You can us
 when accessing this variable.
 
 ```solidity
-pragma solidity ^0.6.6;
+pragma solidity =0.6.6;
 
 import './interfaces/ILiquidityValueCalculator.sol';
 
@@ -120,7 +120,7 @@ Let's put this in a separate function. To implement it, we must:
 The [`UniswapV2Library`](/docs/v2/smart-contracts/library/) has some helpful methods for this.
 
 ```solidity
-pragma solidity ^0.6.6;
+pragma solidity =0.6.6;
 
 import './interfaces/ILiquidityValueCalculator.sol';
 import '@uniswap/v2-periphery/contracts/libraries/UniswapV2Library.sol';
@@ -139,7 +139,7 @@ contract LiquidityValueCalculator is ILiquidityValueCalculator {
 Finally we just need to compute the share value. We will leave that as an exercise to the reader.
 
 ```solidity
-pragma solidity ^0.6.6;
+pragma solidity =0.6.6;
 
 import './interfaces/ILiquidityValueCalculator.sol';
 import '@uniswap/v2-periphery/contracts/libraries/UniswapV2Library.sol';


### PR DESCRIPTION
# Summary of changes

- hardhat for bootstrapping the project (I have no preference, but noticed the current live version is talking about `ethers.js`, and `hre` exposes it by default)
- trailing whitespace removed
- example of deploy script given
- truffle links swapped for hardhat
- fixated the pragma solidity version to `0.6.6` to avoid compile issues (uniswap imports use =0.6.6)
- fixed the Linguist language tag to use `shell-script` as can be seen in [this](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml#L5374) reference. Follwoing the advice [here](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#syntax-highlighting).

# Independent commits

I have broken up the PR into independent commits, in case you do not want / need some changes. So let me know, and I can revert particular commits. Thank you for your hard work!