### PR TITLE
Add missing param for tickBitmap

### DIFF
--- a/docs/V3/reference/core/interfaces/pool/IUniswapV3PoolState.md
+++ b/docs/V3/reference/core/interfaces/pool/IUniswapV3PoolState.md
@@ -92,6 +92,7 @@ a specific position.
 ### tickBitmap
 ```solidity
   function tickBitmap(
+    int16 tickBitmapIndex
   ) external view returns (uint256)
 ```
 Returns 256 packed tick initialized boolean values. See TickBitmap for more information

--- a/docs/V3/reference/core/interfaces/pool/IUniswapV3PoolState.md
+++ b/docs/V3/reference/core/interfaces/pool/IUniswapV3PoolState.md
@@ -92,7 +92,7 @@ a specific position.
 ### tickBitmap
 ```solidity
   function tickBitmap(
-    int16 tickBitmapIndex
+    int16 wordPosition
   ) external view returns (uint256)
 ```
 Returns 256 packed tick initialized boolean values. See TickBitmap for more information


### PR DESCRIPTION
`tickBitmap` apparently works for a specific word, so I've added it as shown in `getPopulatedTicksInWord`.

Sadly this commit also includes a whitespace change, but since this repo seemed to be very very big, I opted not to wait for it to download and make a proper commit locally.

Thanks.