### PR TITLE
docs: ✏️ show view functions in NonfungiblePositionManager as view

### DIFF
--- a/docs/V3/reference/periphery/NonfungiblePositionManager.md
+++ b/docs/V3/reference/periphery/NonfungiblePositionManager.md
@@ -15,7 +15,7 @@ Wraps Uniswap V3 positions in the ERC721 non-fungible token interface
 ```solidity
   function positions(
     uint256 tokenId
-  ) external returns (uint96 nonce, address operator, address token0, address token1, uint24 fee, int24 tickLower, int24 tickUpper, uint128 liquidity, uint256 feeGrowthInside0LastX128, uint256 feeGrowthInside1LastX128, uint128 tokensOwed0, uint128 tokensOwed1)
+  ) external view returns (uint96 nonce, address operator, address token0, address token1, uint24 fee, int24 tickLower, int24 tickUpper, uint128 liquidity, uint256 feeGrowthInside0LastX128, uint256 feeGrowthInside1LastX128, uint128 tokensOwed0, uint128 tokensOwed1)
 ```
 Returns the position information associated with a given token ID.
 
@@ -67,7 +67,7 @@ a method does not exist, i.e. the pool is assumed to be initialized.
 ### tokenURI
 ```solidity
   function tokenURI(
-  ) public returns (string)
+  ) public view returns (string)
 ```
 
 
@@ -171,7 +171,7 @@ must be collected first.
 ### getApproved
 ```solidity
   function getApproved(
-  ) public returns (address)
+  ) public view returns (address)
 ```
 
 Returns the account approved for `tokenId` token.

--- a/docs/V3/reference/periphery/interfaces/INonfungiblePositionManager.md
+++ b/docs/V3/reference/periphery/interfaces/INonfungiblePositionManager.md
@@ -64,7 +64,7 @@ and authorized.
 ```solidity
   function positions(
     uint256 tokenId
-  ) external returns (uint96 nonce, address operator, address token0, address token1, uint24 fee, int24 tickLower, int24 tickUpper, uint128 liquidity, uint256 feeGrowthInside0LastX128, uint256 feeGrowthInside1LastX128, uint128 tokensOwed0, uint128 tokensOwed1)
+  ) external view returns (uint96 nonce, address operator, address token0, address token1, uint24 fee, int24 tickLower, int24 tickUpper, uint128 liquidity, uint256 feeGrowthInside0LastX128, uint256 feeGrowthInside1LastX128, uint128 tokensOwed0, uint128 tokensOwed1)
 ```
 
 Returns the position information associated with a given token ID.

--- a/versioned_docs/version-V3/reference/periphery/NonfungiblePositionManager.md
+++ b/versioned_docs/version-V3/reference/periphery/NonfungiblePositionManager.md
@@ -15,7 +15,7 @@ Wraps Uniswap V3 positions in the ERC721 non-fungible token interface
 ```solidity
   function positions(
     uint256 tokenId
-  ) external returns (uint96 nonce, address operator, address token0, address token1, uint24 fee, int24 tickLower, int24 tickUpper, uint128 liquidity, uint256 feeGrowthInside0LastX128, uint256 feeGrowthInside1LastX128, uint128 tokensOwed0, uint128 tokensOwed1)
+  ) external view returns (uint96 nonce, address operator, address token0, address token1, uint24 fee, int24 tickLower, int24 tickUpper, uint128 liquidity, uint256 feeGrowthInside0LastX128, uint256 feeGrowthInside1LastX128, uint128 tokensOwed0, uint128 tokensOwed1)
 ```
 Returns the position information associated with a given token ID.
 
@@ -67,7 +67,7 @@ a method does not exist, i.e. the pool is assumed to be initialized.
 ### tokenURI
 ```solidity
   function tokenURI(
-  ) public returns (string)
+  ) public view returns (string)
 ```
 
 
@@ -171,7 +171,7 @@ must be collected first.
 ### getApproved
 ```solidity
   function getApproved(
-  ) public returns (address)
+  ) public view returns (address)
 ```
 
 Returns the account approved for `tokenId` token.

--- a/versioned_docs/version-V3/reference/periphery/interfaces/INonfungiblePositionManager.md
+++ b/versioned_docs/version-V3/reference/periphery/interfaces/INonfungiblePositionManager.md
@@ -64,7 +64,7 @@ and authorized.
 ```solidity
   function positions(
     uint256 tokenId
-  ) external returns (uint96 nonce, address operator, address token0, address token1, uint24 fee, int24 tickLower, int24 tickUpper, uint128 liquidity, uint256 feeGrowthInside0LastX128, uint256 feeGrowthInside1LastX128, uint128 tokensOwed0, uint128 tokensOwed1)
+  ) external view returns (uint96 nonce, address operator, address token0, address token1, uint24 fee, int24 tickLower, int24 tickUpper, uint128 liquidity, uint256 feeGrowthInside0LastX128, uint256 feeGrowthInside1LastX128, uint128 tokensOwed0, uint128 tokensOwed1)
 ```
 
 Returns the position information associated with a given token ID.


### PR DESCRIPTION
The `NonfungiblePositionManager` functions in the docs do not have the `view` keyword but the Uni V3 Codebase does.

Example:
1. `positions` - [codebase](https://github.com/Uniswap/uniswap-v3-periphery/blob/878a58a461ae30680acd84d44499058826bf5f3e/contracts/NonfungiblePositionManager.sol#L80) & [docs](https://docs.uniswap.org/reference/periphery/NonfungiblePositionManager#positions)
2. `tokenURI` - [codebase](https://github.com/Uniswap/uniswap-v3-periphery/blob/878a58a461ae30680acd84d44499058826bf5f3e/contracts/NonfungiblePositionManager.sol#L189) & [docs](https://docs.uniswap.org/reference/periphery/NonfungiblePositionManager#tokenuri)
3. `getApproved` - [codebase](https://github.com/Uniswap/uniswap-v3-periphery/blob/878a58a461ae30680acd84d44499058826bf5f3e/contracts/NonfungiblePositionManager.sol#L389) & [docs](https://docs.uniswap.org/reference/periphery/NonfungiblePositionManager#getapproved)