### PR TITLE
remove duplicated function in sample and typos

### DIFF
--- a/versioned_docs/version-V3/guides/providing-liquidity/mint-a-new-position.md
+++ b/versioned_docs/version-V3/guides/providing-liquidity/mint-a-new-position.md
@@ -93,7 +93,7 @@ Now we can call the internal function we previously wrote in [Setting Up Your Co
 ## The Full Example
 
 ```solidity
-    /// @notice Calls the mint function defined in perphery, mints the same amount of each token. For this example we are providing 1000 DAI and 1000 USDC in liquidity
+    /// @notice Calls the mint function defined in periphery, mints the same amount of each token. For this example we are providing 1000 DAI and 1000 USDC in liquidity
     /// @return tokenId The id of the newly minted ERC721
     /// @return liquidity The amount of liquidity for the position
     /// @return amount0 The amount of token0

--- a/versioned_docs/version-V3/guides/providing-liquidity/setting-up-your-contract.md
+++ b/versioned_docs/version-V3/guides/providing-liquidity/setting-up-your-contract.md
@@ -174,13 +174,4 @@ contract LiquidityExamples is IERC721Receiver {
         // operator is msg.sender
         deposits[tokenId] = Deposit({owner: owner, liquidity: liquidity, token0: token0, token1: token1});
     }
-    
-    function _createDeposit(address owner, uint256 tokenId) internal {
-        (, , address token0, address token1, , , , uint128 liquidity, , , , ) =
-            nonfungiblePositionManager.positions(tokenId);
-
-        // set the owner and data for position
-        // operator is msg.sender
-        deposits[tokenId] = Deposit({owner: owner, liquidity: liquidity, token0: token0, token1: token1});
-    }
 ```

--- a/versioned_docs/version-V3/guides/providing-liquidity/the-full-contract.md
+++ b/versioned_docs/version-V3/guides/providing-liquidity/the-full-contract.md
@@ -67,7 +67,7 @@ contract LiquidityExamples is IERC721Receiver {
         deposits[tokenId] = Deposit({owner: owner, liquidity: liquidity, token0: token0, token1: token1});
     }
 
-    /// @notice Calls the mint function defined in perphery, mints the same amount of each token. 
+    /// @notice Calls the mint function defined in periphery, mints the same amount of each token. 
     /// For this example we are providing 1000 DAI and 1000 USDC in liquidity
     /// @return tokenId The id of the newly minted ERC721
     /// @return liquidity The amount of liquidity for the position


### PR DESCRIPTION
* Remove duplicated function `_createDeposit` in the liquidity examples.
*  Fixes typos