### PR TITLE
Fixed add liquidity link

### DIFF
--- a/versioned_docs/version-V2/guides/interface-integration/02-custom-interface-linking.md
+++ b/versioned_docs/version-V2/guides/interface-integration/02-custom-interface-linking.md
@@ -66,7 +66,7 @@ The Pool page is made up of 2 subroutes: `add`, `remove`.
 
 ### Example Usage
 
-`https://app.uniswap.org/#/add/0x6B175474E89094C44Da98b954EedeAC495271d0F-0xdAC17F958D2ee523a2206206994597C13D831ec7`
+`https://app.uniswap.org/#/add/0x6B175474E89094C44Da98b954EedeAC495271d0F/0xdAC17F958D2ee523a2206206994597C13D831ec7`
 
 ## Remove Liquidity
 
@@ -74,8 +74,6 @@ The Pool page is made up of 2 subroutes: `add`, `remove`.
 | :-------- | :-------- | :----------------------------------------------------------------------------------- |
 | Token0    | `address` | Pool to withdraw liquidity from. \(Must be an ERC20 address with an existing token\) |
 | Token1    | `address` | Pool to withdraw liquidity from. \(Must be an ERC20 address with an existing token\) |
-
-Dash seperated.
 
 ### Example Usage
 

--- a/versioned_docs/version-V2/guides/interface-integration/02-custom-interface-linking.md
+++ b/versioned_docs/version-V2/guides/interface-integration/02-custom-interface-linking.md
@@ -66,7 +66,7 @@ The Pool page is made up of 2 subroutes: `add`, `remove`.
 
 ### Example Usage
 
-`https://app.uniswap.org/#/add/0x6B175474E89094C44Da98b954EedeAC495271d0F/0xdAC17F958D2ee523a2206206994597C13D831ec7`
+`https://app.uniswap.org/#/add/v2/0x6B175474E89094C44Da98b954EedeAC495271d0F/0xdAC17F958D2ee523a2206206994597C13D831ec7`
 
 ## Remove Liquidity
 


### PR DESCRIPTION
Looks like the addresses and not dash separated anymore but slash separated. Also point the link to the v2 pool since this page of the documentation is for uniswap v2.

As for the remove liquidity one, it doesn't work for me neither after trying to separate addresses by dash and slash. Not sure if that's expected since I don't have any liquidity.