### PR TITLE
fix glow in the right corner of home screen in dark mode 

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -54,7 +54,7 @@ html[data-theme="dark"] {
 
   /* --ifm-background-color: #191b1f; */
   --ifm-navbar-background-color: #191b1f;
-  --ifm-global-shadow-md: 0 5px 40px rgba(255, 255, 255, 0.448);
+  --ifm-global-shadow-md: 0 5px 4px rgba(255, 255, 255, 0.448);
 
   background-position: 0px -30vh;
   background-repeat: no-repeat;


### PR DESCRIPTION
## What?
There was a glow in the right corner of the main/home screen described in the issue #233. It was because of the large spread radius in the box-shadow property.

## How?
Just changed the value of spread radius to a lower value.

## Testing
This change did not break anything.