### PR TITLE
Fix typos in SDK intro

### DIFF
--- a/SDK_versioned_docs/version-3.0.0/introduction.md
+++ b/SDK_versioned_docs/version-3.0.0/introduction.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 
 # The Uniswap V3 SDK
 
-Welcome to the Uniswap Protocol V3 SDK. To being, we recommend looking at the [**Guides**](./guides/01-quick-start.md), for deeper reference see the [**SDK Github**](https://github.com/Uniswap/uniswap-v3-sdk) repo.
+Welcome to the Uniswap Protocol V3 SDK. To begin, we recommend looking at the [**Guides**](./guides/01-quick-start.md), for deeper reference see the [**SDK Github**](https://github.com/Uniswap/uniswap-v3-sdk) repo.
 
 # Alpha software
 
@@ -24,5 +24,3 @@ Pull requests welcome!
 [![Lint](https://github.com/Uniswap/uniswap-v3-sdk/workflows/Lint/badge.svg)](https://github.com/Uniswap/uniswap-v3-sdk/actions?query=workflow%3ALint)
 [![npm version](https://img.shields.io/npm/v/@uniswap/v3-sdk/latest.svg)](https://www.npmjs.com/package/@uniswap/v3-sdk/v/latest)
 [![npm bundle size (scoped version)](https://img.shields.io/bundlephobia/minzip/@uniswap/v3-sdk/latest.svg)](https://bundlephobia.com/result?p=@uniswap/v3-sdk@latest)
-
-loc


### PR DESCRIPTION
Just noticed some small typos when reading thru the SDK intro. 