### PR TITLE
sqrtRatioX96 -> sqrtPriceX96

### DIFF
--- a/SDK_versioned_docs/version-3.0.0/guides/04-fetching-prices.md
+++ b/SDK_versioned_docs/version-3.0.0/guides/04-fetching-prices.md
@@ -52,7 +52,7 @@ sqrtPriceX96 / (2 ** 96) = sqrt(price)
 # expand the squared fraction
 (sqrtPriceX96 ** 2) / ((2 ** 96) ** 2)  = price
 # multiply the exponents in the denominator to get the final expression
-sqrtRatioX96 ** 2 / 2 ** 192 = price
+sqrtPriceX96 ** 2 / 2 ** 192 = price
 ```
 You will see that the formula in the last step is how the SDK calculates the prices with the functions [`token0Price`](#token0price) and [`token1Price`](#token1price).
 


### PR DESCRIPTION
`sqrtRatioX96` and `sqrtPriceX96` appear interchangable but that isn't described earlier in this doc so it was a bit confusing to me as a reader when the variable name changed in the middle of this code block

Before | After
--- | ---
<img width="963" alt="Screen Shot 2021-11-05 at 12 03 57 PM" src="https://user-images.githubusercontent.com/3699047/140541466-4a671df5-de37-48e9-b504-445f921f24e9.png"> | <img width="964" alt="Screen Shot 2021-11-05 at 12 03 51 PM" src="https://user-images.githubusercontent.com/3699047/140541473-e546495b-4958-4c01-907b-a267ac8881d2.png">

