### PR TITLE
Fix import error and formatting bug in single swap guide

### DIFF
--- a/versioned_docs/version-V3/guides/swaps/single-swaps.md
+++ b/versioned_docs/version-V3/guides/swaps/single-swaps.md
@@ -181,8 +181,8 @@ TransferHelper.safeTransferFrom(DAI, msg.sender, address(this), amountInMaximum)
 pragma solidity =0.7.6;
 pragma abicoder v2;
 
-import '../libraries/TransferHelper.sol';
-import '../interfaces/ISwapRouter.sol';
+import '@uniswap/v3-periphery/contracts/libraries/TransferHelper.sol';
+import '@uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol';
 
 contract SwapExamples {
     // For the scope of these swap examples,
@@ -275,7 +275,5 @@ contract SwapExamples {
             TransferHelper.safeTransfer(DAI, msg.sender, amountInMaximum - amountIn);
         }
     }
-}
-```
 }
 ```


### PR DESCRIPTION
This PR does two things:

1. The imports on the final contract in the Single Swap guide do not compile. They should reference the imports as written earlier in the guide, per the screenshot (`import '@uniswap/v3-periphery/contracts/libraries/TransferHelper.sol'`, not `import '../libraries/TransferHelper.sol'`).
    
    <img width="813" alt="image" src="https://user-images.githubusercontent.com/38447/140543396-465f530d-33e8-44d9-80cb-3c9765dc7e42.png">

2. A markdown error causes weird formatting on the final code snippet. See screenshot below. The diff fixes this by removing the duplicate backticks.

    <img width="882" alt="image" src="https://user-images.githubusercontent.com/38447/140543198-892d8abd-3a30-4d4c-8017-563078bcf135.png">
