### PR TITLE
fix:  correct params desc for multihop-swaps

### DIFF
--- a/versioned_docs/version-V3/guides/swaps/multihop-swaps.md
+++ b/versioned_docs/version-V3/guides/swaps/multihop-swaps.md
@@ -108,8 +108,8 @@ An exact output swap will swap a variable amount of the input token for a fixed 
 - `path`: The path is a sequence of `tokenAddress` `Fee` `tokenAddress`, _encoded in reverse order_, which are the variables needed to compute each pool contract address in our sequence of swaps. The multihop swap router code will automatically find the correct pool with these variables, and execute the swap needed within each pool in our sequence.
 - `recipient`: the destination address of the outbound asset.
 - `deadline`: the unix time after which a transaction will be reverted, to protect against long delays and the increased chance of large price swings therein.
-- `amountIn`: the amount of the inbound asset
-- `amountOutMin`: the minimum amount of the outbound asset, less than which will cause the transaction to revert. For the sake of this example we will set it to `0`, in production one will need to use the SDK to quote an expected price, or an on chain price oracle for more advanced manipulation resistant systems.
+- `amountOut`:  The desired amount of WETH9.
+- `amountInMaximum`: The maximum amount of DAI willing to be swapped for the specified amountOut of WETH9.
 
 ### Calling the function
 


### PR DESCRIPTION
fix params desc for 'Exact Output Multihop Swap'