### PR TITLE
Add TS Config step to Creating a Pool guide.

### DIFF
--- a/SDK_versioned_docs/version-3.0.0/guides/03-creating-a-pool.md
+++ b/SDK_versioned_docs/version-3.0.0/guides/03-creating-a-pool.md
@@ -18,6 +18,17 @@ import { Token } from "@uniswap/sdk-core";
 import { abi as IUniswapV3PoolABI } from "@uniswap/v3-core/artifacts/contracts/interfaces/IUniswapV3Pool.sol/IUniswapV3Pool.json";
 ```
 
+Since we are importing from a json module, we need to create a tsconfig in the root of our project with the following config:
+
+```json
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "resolveJsonModule": true
+  }
+}
+```
+
 Now we'll update the `Contract` object with our imported ABI - and keep the pool address and provider the same as the previous example.
 
 ```typescript


### PR DESCRIPTION
Without this TS config setting, ts-node will throw an error: 

`Cannot find module '@uniswap/v3-core/artifacts/contracts/interfaces/IUniswapV3Pool.sol/IUniswapV3Pool.json'. Consider using '--resolveJsonModule' to import module with '.json' extension.`

Adding in this tsconfig setup fixes the issue.