### PR TITLE
fixed typo in the Auto Router page

### DIFF
--- a/SDK_versioned_docs/version-3.0.0/guides/06-auto-router.md
+++ b/SDK_versioned_docs/version-3.0.0/guides/06-auto-router.md
@@ -91,7 +91,7 @@ const route = await router.route({
   swapType: TradeType.EXACT_IN,
   swapConfig: {
     recipient: myAddress,
-    slippage: new Percent(5, 100),
+    slippageTolerance: new Percent(5, 100),
     deadline: 100
   }
 );
@@ -171,7 +171,7 @@ const route = await router.route({
   tradeType: TradeType.EXACT_IN,
   {
     recipient: myAddress,
-    slippage: new Percent(5, 100),
+    slippageTolerance: new Percent(5, 100),
     deadline: 100
   }
 );


### PR DESCRIPTION
the sdk uses slippageTolerance (a value in the SwapOptions interface) rather than slippage.