### PR TITLE
Updated deposits struct after decreasing liquidity and liquidity example fixes

### DIFF
--- a/smart_contract_examples/LiquidityExamples.sol
+++ b/smart_contract_examples/LiquidityExamples.sol
@@ -142,6 +142,9 @@ contract LiquidityExamples is IERC721Receiver {
         // get liquidity data for tokenId
         uint128 liquidity = deposits[tokenId].liquidity;
         uint128 halfLiquidity = liquidity / 2;
+        
+        // update new liquidity left in the deposit
+        deposits[tokenId].liquidity = liquidity - halfLiquidity;
 
         // amount0Min and amount1Min are price slippage checks
         // if the amount received after burning is not greater than these minimums, transaction will fail

--- a/smart_contract_examples/LiquidityExamples.sol
+++ b/smart_contract_examples/LiquidityExamples.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity 0.7.6;
+pragma solidity =0.7.6;
 pragma abicoder v2;
 
 
@@ -12,7 +12,7 @@ import '@uniswap/v3-periphery/contracts/libraries/TransferHelper.sol';
 import '@uniswap/v3-periphery/contracts/base/LiquidityManagement.sol';
 
 
-contract YewBow is IERC721Receiver, LiquidityManagement {
+contract LiquidityExamples is IERC721Receiver, LiquidityManagement {
 
     INonfungiblePositionManager public immutable nonfungiblePositionManager;
     address public constant DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
@@ -46,7 +46,7 @@ contract YewBow is IERC721Receiver, LiquidityManagement {
     // Note that the operator is recorded as the owner of the deposited NFT
     function onERC721Received(
         address operator,
-        address from,
+        address,
         uint256 tokenId,
         bytes calldata
     ) external override returns (bytes4) {

--- a/versioned_docs/version-V3/guides/providing-liquidity/decrease-liquidity.md
+++ b/versioned_docs/version-V3/guides/providing-liquidity/decrease-liquidity.md
@@ -25,6 +25,9 @@ Here we decrease the liquidity of our position without withdrawing all of it.
         // get liquidity data for tokenId
         uint128 liquidity = deposits[tokenId].liquidity;
         uint128 halfLiquidity = liquidity / 2;
+        
+        // update new liquidity left in the deposit
+        deposits[tokenId].liquidity = liquidity - halfLiquidity;
 
         // amount0Min and amount1Min are price slippage checks
         // if the amount received after burning is not greater than these minimums, transaction will fail


### PR DESCRIPTION
After withdrawing half of the liquidity, the struct of the deposit is not updated.

Updated the `liquidity` variable in the deposit to match the remaining value