### PR TITLE
Delete i package from npm package installation

### DIFF
--- a/SDK_versioned_docs/version-3.0.0/guides/02-using-ethers.md
+++ b/SDK_versioned_docs/version-3.0.0/guides/02-using-ethers.md
@@ -27,7 +27,7 @@ npm init
 npm i typescript --save
 npm i ts-node --save
 npm i @uniswap/v3-sdk --save
-npm i @uniswap/sdk-core i --save
+npm i @uniswap/sdk-core --save
 npm i ethers  --save
 ```
 


### PR DESCRIPTION
Deleted unnecessary package from the step of npm package installation.
If `i` package is used somewhere in this tutorial, feel free to close this PR.