### PR TITLE
Clarify the units of `fee`

### DIFF
--- a/versioned_docs/version-V3/reference/periphery/interfaces/ISwapRouter.md
+++ b/versioned_docs/version-V3/reference/periphery/interfaces/ISwapRouter.md
@@ -2,6 +2,8 @@ Functions for swapping tokens via Uniswap V3
 
 ## Parameter Structs
 
+Note that `fee` is in hundreds of basis points (e.g. the `fee` for a pool at the 0.3% tier is 3000; the `fee` for a pool at the 0.01% tier is 100).
+
 ### ExactInputSingleParams
 
 ```solidity

--- a/versioned_docs/version-V3/reference/periphery/interfaces/ISwapRouter.md
+++ b/versioned_docs/version-V3/reference/periphery/interfaces/ISwapRouter.md
@@ -2,7 +2,7 @@ Functions for swapping tokens via Uniswap V3
 
 ## Parameter Structs
 
-Note that `fee` is in hundreds of basis points (e.g. the `fee` for a pool at the 0.3% tier is 3000; the `fee` for a pool at the 0.01% tier is 100).
+Note that `fee` is in hundredths of basis points (e.g. the `fee` for a pool at the 0.3% tier is 3000; the `fee` for a pool at the 0.01% tier is 100).
 
 ### ExactInputSingleParams
 


### PR DESCRIPTION
I initially didn't realize `fee` was in units of hundredths of bips here; this PR updates the documentation to make it clearer.