### PR TITLE
Edit naming of links for consistency in docs

### DIFF
--- a/SDK_versioned_docs/version-3.0.0/guides/04-creating-a-trade.md
+++ b/SDK_versioned_docs/version-3.0.0/guides/04-creating-a-trade.md
@@ -3,7 +3,7 @@ id: creating-a-trade
 title: Creating a Trade
 ---
 
-This guide extends the previous [creating a pool](03-creating-a-pool.md) and [getting started](./using-ethers) guides by using the `pool` object to quote an estimated amount out for a trade, then creates a trade object that can be used to execute a swap.
+This guide extends the previous [Creating a Pool Instance](03-creating-a-pool.md) and [Using Ethers.js](./using-ethers) guides by using the `pool` object to quote an estimated amount out for a trade, then creates a trade object that can be used to execute a swap.
 
 ## Creating a Quoter Contract Object
 


### PR DESCRIPTION
Helps readers to better traverse through docs with more appropriately named links