### PR TITLE
fix the footnote markdown for concentrated-liquidity.md

### DIFF
--- a/versioned_docs/version-V3/concepts/V3-overview/concentrated-liquidity.md
+++ b/versioned_docs/version-V3/concepts/V3-overview/concentrated-liquidity.md
@@ -39,7 +39,7 @@ Ticks are the boundaries between discrete areas in price space. Ticks are spaced
 
 Ticks function as boundaries for liquidity positions. When a position is created, the provider must choose the lower and upper tick that will represent their position's borders.
 
-As the spot price changes during swapping, the pool contract will continuously exchange the outbound asset for the inbound, progressively using all the liquidity available within the current tick interval[1] until the next tick is reached. At this point, the contract switches to a new tick and activates any dormant liquidity within a position that has a boundary at the newly active tick.
+As the spot price changes during swapping, the pool contract will continuously exchange the outbound asset for the inbound, progressively using all the liquidity available within the current tick interval[^1] until the next tick is reached. At this point, the contract switches to a new tick and activates any dormant liquidity within a position that has a boundary at the newly active tick.
 
 While each pool has the same number of underlying ticks, in practice only a portion of them are able to serve as active ticks. Due to the nature of the v3 smart contracts, tick spacing is directly correlated to the swap fee. Lower fee tiers allow closer potentially active ticks, and higher fees allow a relatively wider spacing of potential active ticks.
 


### PR DESCRIPTION
The footnote reference to "the current tick interval" was originally marked as `... interval[1]`, which was the incorrect syntax to display the footnote.

Fixed the syntax to `... interval[^1]`.