### PR TITLE
Footnote syntax fixes

### DIFF
--- a/versioned_docs/version-V3/concepts/V3-overview/fees.md
+++ b/versioned_docs/version-V3/concepts/V3-overview/fees.md
@@ -5,7 +5,7 @@ title: Fees
 
 ## Swap Fees
 
-Swap fees are distributed pro-rata to all in-range[1] liquidity at the time of the swap. If the spot price moves out of a position’s range, the given liquidity is no longer active and does not generate any fees. If the spot price reverses and reenters the position’s range, the position’s liquidity becomes active again and will generate fees.
+Swap fees are distributed pro-rata to all in-range[^1] liquidity at the time of the swap. If the spot price moves out of a position’s range, the given liquidity is no longer active and does not generate any fees. If the spot price reverses and reenters the position’s range, the position’s liquidity becomes active again and will generate fees.
 
 Swap fees are not automatically reinvested as they were in previous versions of Uniswap. Instead, they are collected separately from the pool and must be manually redeemed when the owner wishes to collect their fees.
 
@@ -29,4 +29,4 @@ Similarly, we anticipate more exotic assets, or those traded rarely, will natura
 
 Uniswap v3 has a protocol fee that can be turned on by UNI governance. Compared to v2, UNI governance has more flexibility in choosing the fraction of swap fees that go to the protocol. For details regarding the protocol fee, see the [**whitepaper**](https://uniswap.org/whitepaper-v3.pdf).
 
-[1] In-range liquidity refers to the liquidity contained in any positions which span both sides of the spot price.
+[^1] In-range liquidity refers to the liquidity contained in any positions which span both sides of the spot price.

--- a/versioned_docs/version-V3/concepts/V3-overview/fees.md
+++ b/versioned_docs/version-V3/concepts/V3-overview/fees.md
@@ -29,4 +29,4 @@ Similarly, we anticipate more exotic assets, or those traded rarely, will natura
 
 Uniswap v3 has a protocol fee that can be turned on by UNI governance. Compared to v2, UNI governance has more flexibility in choosing the fraction of swap fees that go to the protocol. For details regarding the protocol fee, see the [**whitepaper**](https://uniswap.org/whitepaper-v3.pdf).
 
-[^1] In-range liquidity refers to the liquidity contained in any positions which span both sides of the spot price.
+[^1]: In-range liquidity refers to the liquidity contained in any positions which span both sides of the spot price.

--- a/versioned_docs/version-V3/concepts/V3-overview/swaps.md
+++ b/versioned_docs/version-V3/concepts/V3-overview/swaps.md
@@ -5,7 +5,7 @@ title: Swaps
 
 ## Introduction
 
-Swaps are the most common way of interacting with the Uniswap protocol. For end-users, swapping is straightforward: a user selects an ERC-20 token that they own and a token they would like to trade it for. Executing a swap sells the currently owned tokens for the proportional[1] amount of the tokens desired, minus the swap fee, which is awarded to liquidity providers[^2]. Swapping with the Uniswap protocol is a permissionless process.
+Swaps are the most common way of interacting with the Uniswap protocol. For end-users, swapping is straightforward: a user selects an ERC-20 token that they own and a token they would like to trade it for. Executing a swap sells the currently owned tokens for the proportional[^1] amount of the tokens desired, minus the swap fee, which is awarded to liquidity providers[^2]. Swapping with the Uniswap protocol is a permissionless process.
 
 > note: Using web interfaces (websites) to swap via the Uniswap protocol can introduce additional permission structures, and may result in different execution behavior compared to using the Uniswap protocol directly. To learn more about the differences between the protocol and a web interface, see What is Uniswap.
 
@@ -41,6 +41,6 @@ Price impact and slippage can both change while a transaction is pending, which 
 
 - **INSUFFICIENT_OUTPUT_AMOUNT** : When a user submits a swap, the Uniswap interface will send an estimate of how much of the purchased token the user should expect to receive. If the anticipated output amount of a swap does not match the estimate within a certain margin of error (the slippage tolerance), the swap will be canceled. This attempts to protect the user from any drastic and unfavorable price changes while their transaction is pending.
 
-[^1] Proportional in this instance takes into account many factors, including the relative price of one token in terms of the other, slippage, price impact, and other factors related to the open and adversarial nature of Ethereum.
-[^2] For information about liquidity provision, see the liquidity user guide
-[^3] The Uniswap interface informs the user about the circumstances of their swap, but it is not guaranteed.
+[^1]: Proportional in this instance takes into account many factors, including the relative price of one token in terms of the other, slippage, price impact, and other factors related to the open and adversarial nature of Ethereum.
+[^2]: For information about liquidity provision, see the liquidity user guide
+[^3]: The Uniswap interface informs the user about the circumstances of their swap, but it is not guaranteed.


### PR DESCRIPTION
Fixed syntax errors for footnote references in `fees.md` and `swaps.md`.

For footnotes, `[^#]` would only create a one-directional linking. To display the return-to-source button, one would need to use `[^#]:`.