### PR TITLE
Add "Liquidity" and "Slot 0" to ABI

### DIFF
--- a/SDK_versioned_docs/version-3.0.0/guides/02-using-ethers.md
+++ b/SDK_versioned_docs/version-3.0.0/guides/02-using-ethers.md
@@ -66,6 +66,8 @@ const poolImmutablesAbi = [
   "function fee() external view returns (uint24)",
   "function tickSpacing() external view returns (int24)",
   "function maxLiquidityPerTick() external view returns (uint128)",
+  "function liquidity() external view returns (uint128)",
+  "function slot0() external view returns (uint160 sqrtPriceX96, int24 tick, uint16 observationIndex, uint16 observationCardinality, uint16   observationCardinalityNext, uint8 feeProtocol, bool unlocked)"
 ];
 ```
 


### PR DESCRIPTION
Need to query liquidity and slot 0 to create Pool object, but they are not in the ethers ABI.

Ethers doesnt like \n so just did one line. could also concatination syntax or w/e