### PR TITLE
Fix "Fixture path not found:" in Swap Widget docs

### DIFF
--- a/SDK_versioned_docs/version-3.0.0/widgets/swap-widget.mdx
+++ b/SDK_versioned_docs/version-3.0.0/widgets/swap-widget.mdx
@@ -15,7 +15,7 @@ This guide walks you through the steps to embed the swap widget in your web3 dec
 
 Here’s a live preview of the swap widget. Please note that wallet connect is not supported here in the documentation. Your app will be responsible for providing a method to connect a wallet.
 
-<iframe width="360" height="360" scrolling="no" src="https://widgets-uniswap.vercel.app/_renderer.html?_fixtureId=%7B%22path%22%3A%22src%2Flib%2Fcomponents%2FSwap%2FSwap.fixture.tsx%22%2C%22name%22%3Anull%7D"></iframe>
+<iframe width="360" height="360" scrolling="no" src="https://widgets-uniswap.vercel.app/_renderer.html?_fixtureId=%7B%22path%22%3A%22src%2Fcosmos%2FSwap.fixture.tsx%22%2C%22name%22%3Anull%7D"></iframe>
 
 With the swap widget, your users can trade for any ERC-20 token without leaving your app! Example use cases include:
 


### PR DESCRIPTION
you can see an error here
https://docs.uniswap.org/sdk/widgets/swap-widget

<img width="300" alt="Screenshot 2022-05-06 at 17 36 25" src="https://user-images.githubusercontent.com/1488195/167143786-acd31184-800f-42b1-8165-cdce8f2ed4f8.png">

bug caused by this changes
https://github.com/Uniswap/widgets/commit/882bd11e6a297a71eff066d6f717583833178366