### PR TITLE
Update 07-swap-and-add.md

### DIFF
--- a/SDK_versioned_docs/version-3.0.0/guides/liquidity/07-swap-and-add.md
+++ b/SDK_versioned_docs/version-3.0.0/guides/liquidity/07-swap-and-add.md
@@ -55,7 +55,7 @@ Now call the `routeToRatio` method on the Auto Router. This function will return
 
 `swapAndAddOptions` [optional]
 
-- If [swapAndAddOptions](https://github.com/Uniswap/smart-order-router/blob/b26ffdc978ab1076c817392ab20ed2df325daf7a/src/routers/router.ts#L130) is included, routeToRatio will return the calldata for executing the atomic swap-and-add. These options contain `swapConfig` and `addLiquidityOptions`. `swapConfig` configures to set a recipient of leftover dust from swap, slippageTolerance, deadline, inputTokenPermit and outputTokenPermit. `addLiquidityOptions` must contain a `tokenId` to add to an existing position, or `recipient` to mint a new one. It also includes a slippage tolerance and deadline for adding liquidity.
+- If [swapAndAddOptions](https://github.com/Uniswap/smart-order-router/blob/b26ffdc978ab1076c817392ab20ed2df325daf7a/src/routers/router.ts#L130) is included, routeToRatio will return the calldata for executing the atomic swap-and-add. These options contain `swapOptions` and `addLiquidityOptions`. `swapOptions` configures to set a recipient of leftover dust from swap, slippageTolerance, deadline, inputTokenPermit and outputTokenPermit. `addLiquidityOptions` must contain a `tokenId` to add to an existing position, or `recipient` to mint a new one. It also includes a slippage tolerance and deadline for adding liquidity.
 
 `routingConfig` [optional]
 
@@ -106,9 +106,9 @@ const routeToRatioResponse = await router.routeToRatio(
      maxIterations: 6,
    },
    swapAndAddOptions: {
-     swapConfig: {
+     swapOptions: {
        recipient: <myAddress>,
-       slippage: new Percent(5, 100),
+       slippageTolerance: new Percent(5, 100),
        deadline: 100
      },
      addLiquidityOptions: {


### PR DESCRIPTION
In "@uniswap/smart-order-router" v2.5.30

The attributs  of `swapAndAddOptions` of `routeToRatio` parameter does not have the correct names.

`swapConfig` is now `swapOptions` and `slippage` is `slippageTolerance`.