### PR TITLE
Fix typo in 01-quick-start.md

### DIFF
--- a/SDK_versioned_docs/version-3.0.0/guides/01-quick-start.md
+++ b/SDK_versioned_docs/version-3.0.0/guides/01-quick-start.md
@@ -5,7 +5,7 @@ title: Quick Start
 
 The Uniswap SDK is separate from the Uniswap protocol. It is designed to assist developers when interacting with the protocol in any environment that can execute JavaScript, such as websites or node scripts. With the SDK, you can manipulate data that has been queried from the EVM using libraries that assist with several needs, such as data modeling and protection from rounding errors.
 
-The following guides will help you use [ethers.js](https://docs.ethers.io/v5/) to return state date from the EVM, and the Uniswap V3 SDK to manipulate it once it has been retrieved.
+The following guides will help you use [ethers.js](https://docs.ethers.io/v5/) to return state data from the EVM, and the Uniswap V3 SDK to manipulate it once it has been retrieved.
 
 # Installation
 


### PR DESCRIPTION
From `state date from the EVM` to `state data from the EVM`