### PR TITLE
Incorrect usage of Address type replaced with string type

### DIFF
--- a/SDK_versioned_docs/version-3.0.0/guides/02-using-ethers.md
+++ b/SDK_versioned_docs/version-3.0.0/guides/02-using-ethers.md
@@ -44,7 +44,6 @@ For this example, we're using an infura endpoint. If you don't have access to an
 
 ```typescript
 import { ethers } from 'ethers'
-import { Address } from 'cluster'
 
 const provider = new ethers.providers.JsonRpcProvider('<YOUR-ENDPOINT-HERE>')
 ```
@@ -81,9 +80,9 @@ Now we'll create an interface with all the data we're going to return, each assi
 
 ```typescript
 interface Immutables {
-  factory: Address
-  token0: Address
-  token1: Address
+  factory: string
+  token0: string
+  token1: string
   fee: number
   tickSpacing: number
   maxLiquidityPerTick: number
@@ -145,7 +144,6 @@ If everything worked correctly, you should see something like this:
 
 ```typescript
 import { ethers } from 'ethers'
-import { Address } from 'cluster'
 
 const provider = new ethers.providers.JsonRpcProvider('<YOUR_ENDPOINT_HERE>')
 
@@ -163,9 +161,9 @@ const poolImmutablesAbi = [
 const poolContract = new ethers.Contract(poolAddress, poolImmutablesAbi, provider)
 
 interface Immutables {
-  factory: Address
-  token0: Address
-  token1: Address
+  factory: string
+  token0: string
+  token1: string
   fee: number
   tickSpacing: number
   maxLiquidityPerTick: number


### PR DESCRIPTION
Node.js `cluster` library, from which `Address` is imported, is used to run multiple instances of Node.js that can distribute workloads among their application threads. It has nothing to do with Ethereum addresses. It was probably auto-imported by IDE, when someone by mistake used `Address` as a type.

The very same code snippet was used in the next guide [Creating a Pool Instance](https://docs.uniswap.org/sdk/guides/creating-a-pool), and there the address values are correctly typed as `string`.