### PR TITLE
Removed the Website Link

### DIFF
--- a/versioned_docs/version-V2/reference/smart-contracts/07-common-errors.md
+++ b/versioned_docs/version-V2/reference/smart-contracts/07-common-errors.md
@@ -81,8 +81,6 @@ This is a result of a transaction that took too long to be broadcast to the main
 
 Uniswap does not set gas prices natively, so most users default to the suggested gas prices in metamask. Sometimes metamask gets it wrong, though, and sets the gas price too low. If a swap takes more than 20 minutes to execute, the core contract won’t allow it to go through.
 
-Finding accurate gas prices can be a challenge, for the time being, we like [Gas Now](https://www.gasnow.org/).
-
 # Action Requires an Active Reserve
 
 VM Exception While Processing Transaction: Action Requires an Active Reserve


### PR DESCRIPTION
Removed the [Gas Now](https://www.gasnow.org/) link and the corresponding sentence.

The [Gas Now](https://www.gasnow.org/) domain redirects to the Bitcoin Website (as of writing this PR).