### PR TITLE
OracleLibrary.md mistaken type

### DIFF
--- a/versioned_docs/version-V3/reference/periphery/libraries/OracleLibrary.md
+++ b/versioned_docs/version-V3/reference/periphery/libraries/OracleLibrary.md
@@ -24,7 +24,7 @@ Fetches time-weighted average tick using Uniswap V3 oracle
 
 | Name                      | Type    | Description                                                                       |
 | :------------------------ | :------ | :-------------------------------------------------------------------------------- |
-| `timeWeightedAverageTick` | address | The time-weighted average tick from (block.timestamp - period) to block.timestamp |
+| `timeWeightedAverageTick` | int24 | The time-weighted average tick from (block.timestamp - period) to block.timestamp |
 
 ### getQuoteAtTick
 


### PR DESCRIPTION
fixed an incorrect type annotation from `address` to `int24` for `timeWeightedAverageTick`