### PR TITLE
fix: remove referrer user property

### DIFF
--- a/src/theme/Root.tsx
+++ b/src/theme/Root.tsx
@@ -33,9 +33,7 @@ export default function Root({ children }: React.PropsWithChildren<{ open: boole
 
   // Fires on initial render of the page
   useEffect(() => {
-    sendAnalyticsEvent(EventName.APP_LOADED, {
-      referer: document.referrer,
-    })
+    sendAnalyticsEvent(EventName.APP_LOADED)
     user.set(CustomUserProperties.USER_AGENT, navigator.userAgent)
     user.set(CustomUserProperties.BROWSER, getBrowser())
     user.set(CustomUserProperties.SCREEN_RESOLUTION_HEIGHT, window.screen.height)


### PR DESCRIPTION
# Notes

The `referrer` property is automatically tracked by the analytics package at the user level.