### PR TITLE
fix: Uniswap name typo

### DIFF
--- a/docs/contracts/v2/overview.md
+++ b/docs/contracts/v2/overview.md
@@ -4,7 +4,7 @@ title: Overview
 sidebar_position: 1
 ---
 
-# The Uuniswap V2 Smart Contracts
+# The Uniswap V2 Smart Contracts
 
 Welcome to the Uniswap protocol V2 docs.
 


### PR DESCRIPTION
Fixes a small typo on the V2 overview docs (Uuniswap -> Uniswap)