### PR TITLE
feat: improved code link styling

### DIFF
--- a/docs/sdk/v3/guides/02-quoting.md
+++ b/docs/sdk/v3/guides/02-quoting.md
@@ -73,7 +73,7 @@ The return values of these methods will become inputs to the quote fetching func
 
 Like we did for the Pool contract, we need to construct an instance of an **ethers** `Contract` for our Quoter contract in order to interact with it:
 ```js reference title="Setting up a reference to the Quoter contract" referenceLinkText="View on Github" customStyling
-https://github.com/Uniswap/examples/blob/1ef393c2b8f8206a3dc5a42562382c267bcc361b/v3-sdk/quoting/src/example/Example.tsx#L32
+https://github.com/Uniswap/examples/blob/a88c8bc7a16ae15922c4ee86af796a9e430aad29/v3-sdk/quoting/src/example/Example.tsx#L46-L49
 ```
 
 We get access to the contract's ABI through the [@uniswap/v3-periphery](https://www.npmjs.com/package/@uniswap/v3-periphery) package, which holds the periphery smart contracts of the Uniswap V3 protocol:

--- a/docs/sdk/v3/guides/02-quoting.md
+++ b/docs/sdk/v3/guides/02-quoting.md
@@ -33,14 +33,14 @@ At the end of the guide, we should be able to fetch a quote for the given input 
 To interact with the **USDC - WETH** Pool contract, we first need to compute its deployment address.
 The SDK provides a utility method for that:
 
-```js reference title="Computing the Pool's address"
+```js reference title="Computing the Pool's address" referenceLinkText="View on Github" customStyling
 https://github.com/Uniswap/examples/blob/a88c8bc7a16ae15922c4ee86af796a9e430aad29/v3-sdk/quoting/src/example/Example.tsx#L20-L25
 ```
 Since each *Uniswap V3 Pool* is uniquely identified by 3 characteristics (token in, token out, fee), we use those
 in combination with the address of the *PoolFactory* contract to compute the address of the **USDC - ETH** Pool.
 These parameters have already been defined in our configuration file:
 
-```ts reference title="Configuration Parameters"
+```ts reference title="Configuration Parameters" referenceLinkText="View on Github" customStyling
 https://github.com/Uniswap/examples/blob/1ef393c2b8f8206a3dc5a42562382c267bcc361b/v3-sdk/quoting/src/config.ts#L34-L39
 ```
 
@@ -48,14 +48,14 @@ https://github.com/Uniswap/examples/blob/1ef393c2b8f8206a3dc5a42562382c267bcc361
 
 Now that we have the deployment address of the **USDC - ETH** Pool, we can construct an instance of an **ethers** `Contract` to interact with it:
 
-```js reference title="Setting up a reference to the Pool contract"
+```js reference title="Setting up a reference to the Pool contract" referenceLinkText="View on Github" customStyling
 https://github.com/Uniswap/examples/blob/e1fbf8612e2e7d0b86a25637cc75881ff809ca2e/v3-sdk/quoting/src/example/Example.tsx#L27-L31
 ```
 
 To construct the *Contract* we just need to provide the address of the contract, its ABI and the provider that will carry out the RPC call for us.
 We get access to the contract's ABI through the [@uniswap/v3-core](https://www.npmjs.com/package/@uniswap/v3-core) package, which holds the core smart contracts of the Uniswap V3 protocol:
 
-```js reference title="Uniswap V3 Pool smart contract ABI"
+```js reference title="Uniswap V3 Pool smart contract ABI" referenceLinkText="View on Github" customStyling
 https://github.com/Uniswap/examples/blob/a88c8bc7a16ae15922c4ee86af796a9e430aad29/v3-sdk/quoting/src/example/Example.tsx#L7
 ```
 
@@ -63,7 +63,7 @@ Having constructed our reference to the contract, we can now access its methods 
 We use a batch `Promise` call. This approach queries state data concurrently, rather than sequentially, to avoid out of sync data that may be returned if sequential queries are executed over the span of two blocks:
 
 
-```js reference title="Getting Pool metadata from the Pool smart contact"
+```js reference title="Getting Pool metadata from the Pool smart contact" referenceLinkText="View on Github" customStyling
 https://github.com/Uniswap/examples/blob/a88c8bc7a16ae15922c4ee86af796a9e430aad29/v3-sdk/quoting/src/example/Example.tsx#L32-L36
 ```
 
@@ -72,13 +72,13 @@ The return values of these methods will become inputs to the quote fetching func
 ### Setting up a reference to the Quoter contract and getting a quote for the pool
 
 Like we did for the Pool contract, we need to construct an instance of an **ethers** `Contract` for our Quoter contract in order to interact with it:
-```js reference title="Setting up a reference to the Quoter contract"
+```js reference title="Setting up a reference to the Quoter contract" referenceLinkText="View on Github" customStyling
 https://github.com/Uniswap/examples/blob/1ef393c2b8f8206a3dc5a42562382c267bcc361b/v3-sdk/quoting/src/example/Example.tsx#L32
 ```
 
 We get access to the contract's ABI through the [@uniswap/v3-periphery](https://www.npmjs.com/package/@uniswap/v3-periphery) package, which holds the periphery smart contracts of the Uniswap V3 protocol:
 
-```js reference title="Uniswap V3 Quoter smart contract ABI"
+```js reference title="Uniswap V3 Quoter smart contract ABI" referenceLinkText="View on Github" customStyling
 https://github.com/Uniswap/examples/blob/22ae27bafdbff895ee2168584154626ef4af4d30/v3-sdk/quoting/src/example/Example.tsx#L6
 ```
 
@@ -92,7 +92,7 @@ To get around this difficulty, we can use the `callStatic` method provided by th
 This is a useful method that submits a state-changing transaction to an Ethereum node, but asks the node to simulate the state change, rather than to execute it. 
 Our script can then return the result of the simulated state change:
 
-```js reference title="Getting Quotes from the Quoter contract"
+```js reference title="Getting Quotes from the Quoter contract" referenceLinkText="View on Github" customStyling
 https://github.com/Uniswap/examples/blob/1ef393c2b8f8206a3dc5a42562382c267bcc361b/v3-sdk/quoting/src/example/Example.tsx#L35-L41
 ```
 

--- a/docs/sdk/v3/guides/02-quoting.md
+++ b/docs/sdk/v3/guides/02-quoting.md
@@ -73,7 +73,7 @@ The return values of these methods will become inputs to the quote fetching func
 
 Like we did for the Pool contract, we need to construct an instance of an **ethers** `Contract` for our Quoter contract in order to interact with it:
 ```js reference title="Setting up a reference to the Quoter contract" referenceLinkText="View on Github" customStyling
-https://github.com/Uniswap/examples/blob/a88c8bc7a16ae15922c4ee86af796a9e430aad29/v3-sdk/quoting/src/example/Example.tsx#L46-L49
+https://github.com/Uniswap/examples/blob/a88c8bc7a16ae15922c4ee86af796a9e430aad29/v3-sdk/quoting/src/example/Example.tsx#L46-L50
 ```
 
 We get access to the contract's ABI through the [@uniswap/v3-periphery](https://www.npmjs.com/package/@uniswap/v3-periphery) package, which holds the periphery smart contracts of the Uniswap V3 protocol:

--- a/docs/sdk/v3/guides/03-trading.md
+++ b/docs/sdk/v3/guides/03-trading.md
@@ -3,6 +3,6 @@ id: trading
 title: Executing a Trading
 ---
 
-```js reference title="Example"
+```js reference title="Example X" referenceLinkText="View on Github" customStyling
 https://github.com/Uniswap/examples/blob/1ef393c2b8f8206a3dc5a42562382c267bcc361b/v3-sdk/quoting/src/example/Example.tsx#L14-L19
 ```

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@emotion/react": "^11.4.0",
     "@emotion/styled": "^11.3.0",
     "@mdx-js/react": "^1.6.21",
-    "@saucelabs/theme-github-codeblock": "https://github.com/Uniswap/docusaurus-theme-github-codeblock.git#f55fe4caed9fce974c9b82bf2164f76cc5509eefy",
+    "@saucelabs/theme-github-codeblock": "https://github.com/Uniswap/docusaurus-theme-github-codeblock.git#f55fe4caed9fce974c9b82bf2164f76cc5509eef",
     "@types/react": "^17.0.11",
     "@uniswap/analytics": "1.1.0",
     "@uniswap/analytics-events": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@emotion/react": "^11.4.0",
     "@emotion/styled": "^11.3.0",
     "@mdx-js/react": "^1.6.21",
-    "@saucelabs/theme-github-codeblock": "^0.1.1",
+    "@saucelabs/theme-github-codeblock": "https://github.com/Uniswap/docusaurus-theme-github-codeblock.git#f55fe4caed9fce974c9b82bf2164f76cc5509eefy",
     "@types/react": "^17.0.11",
     "@uniswap/analytics": "1.1.0",
     "@uniswap/analytics-events": "1.1.1",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -508,6 +508,13 @@ html[data-theme='dark'] .DocSearch-Hit a {
   }
 }
 
+.github-codeblock-reference-link {
+  margin-top: -16px;
+  padding-bottom: 13px;
+  font-size: 0.7em;
+  text-align: right;
+}
+
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *

--- a/yarn.lock
+++ b/yarn.lock
@@ -2601,10 +2601,9 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.11.tgz#aeb16f50649a91af79dbe36574b66d0f9e4d9f71"
   integrity sha512-3NsZsJIA/22P3QUyrEDNA2D133H4j224twJrdipXN38dpnIOzAbUDtOwkcJ5pXmn75w7LSQDjA4tO9dm1XlqlA==
 
-"@saucelabs/theme-github-codeblock@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@saucelabs/theme-github-codeblock/-/theme-github-codeblock-0.1.1.tgz#d2caa3fbf56c38ae2fe974871f1188226bb57d92"
-  integrity sha512-iHzODYjcUAYI4eJzLrNCw/Iq9SWxCKB/cMgEKHjRmNMb2NKch1dsI2ZSCg8lNedIPmOaRfqHT29hLyMoc/5Wpg==
+"@saucelabs/theme-github-codeblock@https://github.com/Uniswap/docusaurus-theme-github-codeblock.git#f55fe4caed9fce974c9b82bf2164f76cc5509eef":
+  version "0.2.0"
+  resolved "https://github.com/Uniswap/docusaurus-theme-github-codeblock.git#f55fe4caed9fce974c9b82bf2164f76cc5509eef"
 
 "@sideway/address@^4.1.3":
   version "4.1.3"


### PR DESCRIPTION
- Pulls in a [fork](https://github.com/Uniswap/docusaurus-theme-github-codeblock) of [@saucelabs/theme-github-codeblock](https://github.com/saucelabs/docusaurus-theme-github-codeblock) which seems to likely be [unmaintained](https://github.com/saucelabs/docusaurus-theme-github-codeblock/pull/19#issuecomment-1096936381). 
- Updates existing usages to shorten link text and style it
- Fixes a code link with longer lines leftover from before reformatting examples for readability

In the event the plugin is actively maintained, https://github.com/saucelabs/docusaurus-theme-github-codeblock/pull/24 has been filed and the fork will be removed once that PR has been merged and a new version with these capabilities is available