### PR TITLE
Fix typo in smart contracts integration title in the docs index

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -384,7 +384,7 @@ export default function Home() {
             </div>
           </div>
           <div>
-            <h2>Integrate your smart contacts</h2>
+            <h2>Integrate your smart contracts</h2>
             <p>Explore these guided tutorials to get started integrating with Uniswap in your smart contracts.</p>
             <div>
               {smartContractGuides.map((action) => (


### PR DESCRIPTION
This change fixes a typo in the Uniswap Docs index, in the "Integrate your smart contracts" section.
The title had the word "contacts" instead of "contracts".