### PR TITLE
Update 06-getting-pair-addresses.md

### DIFF
--- a/docs/contracts/v2/guides/smart-contract-integration/06-getting-pair-addresses.md
+++ b/docs/contracts/v2/guides/smart-contract-integration/06-getting-pair-addresses.md
@@ -34,7 +34,7 @@ address factory = 0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f;
 address token0 = 0xCAFE000000000000000000000000000000000000; // change me!
 address token1 = 0xF00D000000000000000000000000000000000000; // change me!
 
-address pair = address(uint(keccak256(abi.encodePacked(
+address pair = address(uint160(bytes20(keccak256(abi.encodePacked(
   hex'ff',
   factory,
   keccak256(abi.encodePacked(token0, token1)),


### PR DESCRIPTION
FIX the Error: 
In this update,  we will get first 20 bytes,  and convert it into uint, then it will easily get explicit converted into address