### PR TITLE
Updated 404 documentation link

### DIFF
--- a/docs/contracts/v2/guides/interface-integration/03-iframe-integration.mdx
+++ b/docs/contracts/v2/guides/interface-integration/03-iframe-integration.mdx
@@ -4,7 +4,7 @@ title: Iframe Integration
 ---
 
 :::note Swap Widget
-These docs are deprecated. Please refer to [Swap Widget](../../../swap-widget/overview) to embed the Uniswap swap widget as a React component in your website in 2 minutes.
+These docs are deprecated. Please refer to [Swap Widget](../../../swap-widget/guides/getting-started) to embed the Uniswap swap widget as a React component in your website in 2 minutes. 
 :::
 
 Uniswap can be used within other sites as an iframe. An iframe shows an exact version of the Uniswap frontend site and can have custom prefilled settings.


### PR DESCRIPTION
The link for the swap widget documentation isn't working. I've updated the docs to point to it to the swap widget guide.