### PR TITLE
Fix parameter typo in comment in Multihop Swaps doc

### DIFF
--- a/docs/contracts/v3/guides/swaps/multihop-swaps.md
+++ b/docs/contracts/v3/guides/swaps/multihop-swaps.md
@@ -83,7 +83,7 @@ Exact input multi hop swaps will swap a fixed amount on a given input token for 
         TransferHelper.safeApprove(DAI, address(swapRouter), amountIn);
 
         // Multiple pool swaps are encoded through bytes called a `path`. A path is a sequence of token addresses and poolFees that define the pools used in the swaps.
-        // The format for pool encoding is (tokenIn, fee, tokenOut/tokenIn, fee, tokenOut) where tokenIn/tokenOut parameter is the shared token across the pools.
+        // The format for pool encoding is (tokenIn, fee, tokenOut/tokenIn, fee, tokenOut) where tokenOut/tokenIn parameter is the shared token across the pools.
         // Since we are swapping DAI to USDC and then USDC to WETH9 the path encoding is (DAI, 0.3%, USDC, 0.3%, WETH9).
         ISwapRouter.ExactInputParams memory params =
             ISwapRouter.ExactInputParams({

--- a/docs/contracts/v3/guides/swaps/multihop-swaps.md
+++ b/docs/contracts/v3/guides/swaps/multihop-swaps.md
@@ -197,7 +197,7 @@ contract SwapExamples {
         TransferHelper.safeApprove(DAI, address(swapRouter), amountIn);
 
         // Multiple pool swaps are encoded through bytes called a `path`. A path is a sequence of token addresses and poolFees that define the pools used in the swaps.
-        // The format for pool encoding is (tokenIn, fee, tokenOut/tokenIn, fee, tokenOut) where tokenIn/tokenOut parameter is the shared token across the pools.
+        // The format for pool encoding is (tokenIn, fee, tokenOut/tokenIn, fee, tokenOut) where tokenOut/tokenIn parameter is the shared token across the pools.
         // Since we are swapping DAI to USDC and then USDC to WETH9 the path encoding is (DAI, 0.3%, USDC, 0.3%, WETH9).
         ISwapRouter.ExactInputParams memory params =
             ISwapRouter.ExactInputParams({


### PR DESCRIPTION
Hi everyone, I think there might be a typo in the [Multihop Swaps - Calling the function](https://docs.uniswap.org/contracts/v3/guides/swaps/multihop-swaps#calling-the-function) example.

```solidity
        // The format for pool encoding is (tokenIn, fee, tokenOut/tokenIn, fee, tokenOut) where tokenIn/tokenOut parameter is the shared token across the pools.
```

If I'm not mistaken, `tokenIn/tokenOut` should be replaced by `tokenOut/tokenIn` to be coherent with the early part of the comment.