### PR TITLE
Update flash-callback.md

### DIFF
--- a/docs/contracts/v3/guides/flash-integrations/flash-callback.md
+++ b/docs/contracts/v3/guides/flash-integrations/flash-callback.md
@@ -24,7 +24,7 @@ Declare a variable `decoded` in memory and assign it to the [**decoded data**](h
         FlashCallbackData memory decoded = abi.decode(data, (FlashCallbackData));
 ```
 
-Each callback must be validated to verify that the call originated from a genuine V3 pool. Otherwise, the pool contract would be vulnerable to attack via an EOA manipulating the callback function.
+Each callback must be validated to verify that the call originated from a genuine V3 pool. Otherwise, the PairFlash contract would be vulnerable to attack via an EOA manipulating the callback function.
 
 ```solidity
         CallbackValidation.verifyCallback(factory, decoded.poolKey);


### PR DESCRIPTION
This PR modifies the Uniswap V3 documentation to specify the risk of the PairFlash contract to potential attacks. Instead of stating a generic risk to the pool contract, it highlights the PairFlash contract in particular, which can be manipulated via an EOA if the callback function isn't properly validated. The aim is to provide more accurate and detailed information, assisting developers in understanding the potential vulnerabilities and how to mitigate them effectively.