### PR TITLE
fix: updated widget height

### DIFF
--- a/docs/sdk/swap-widget/guides/swap-widget.mdx
+++ b/docs/sdk/swap-widget/guides/swap-widget.mdx
@@ -16,7 +16,7 @@ Here’s a live preview of the swap widget.
 
 <iframe
   width="376"
-  height="376"
+  height="486"
   scrolling="no"
   src="https://widgets-uniswap.vercel.app/_renderer.html?_fixtureId=%7B%22path%22%3A%22src%2Fcosmos%2FSwap.fixture.tsx%22%2C%22name%22%3Anull%7D"
 ></iframe>
@@ -100,8 +100,8 @@ import '@uniswap/widgets/fonts.css'
 import { provider } from './your/provider'
 
 // We recommend you pass your own JSON-RPC endpoints.
-const jsonRpcUrlMap = { 
-  1: ['https://mainnet.infura.io/v3/<YOUR_INFURA_PROJECT_ID>'], 
+const jsonRpcUrlMap = {
+  1: ['https://mainnet.infura.io/v3/<YOUR_INFURA_PROJECT_ID>'],
   3: ['https://ropsten.infura.io/v3/<YOUR_INFURA_PROJECT_ID>']
 }
 
@@ -116,7 +116,7 @@ function App() {
 
 JSON-RPC endpoints are used to read data when no `provider` is connected. We strongly recommend you pass either a Web3 Provider to the `provider` prop, or JSON-RPC endpoint URLs to the `jsonRpcUrlMap` prop.
 
-The widget will use these endpoints to fetch on-chain data and submit transactions for signature. If the user connects a MetaMask wallet, the widget will use the JSON-RPC provided by MetaMask when possible. [(See a list of all chains supported on widget.)](https://github.com/Uniswap/widgets/blob/main/src/constants/chains.ts#L4) 
+The widget will use these endpoints to fetch on-chain data and submit transactions for signature. If the user connects a MetaMask wallet, the widget will use the JSON-RPC provided by MetaMask when possible. [(See a list of all chains supported on widget.)](https://github.com/Uniswap/widgets/blob/main/src/constants/chains.ts#L4)
 
 If you don’t yet have JSON-RPC endpoints, you can easily create them with services like [Infura](https://infura.io/product/ethereum) or [Alchemy](https://www.alchemy.com/supernode).
 


### PR DESCRIPTION
The example widget shown embedded in the docs cannot be swapped due to the height of the iframe. To fix this problem, update the height of the iframe and the problem is solved.