### PR TITLE
fix: Add collect call before sending to owner

### DIFF
--- a/docs/contracts/v3/guides/providing-liquidity/decrease-liquidity.md
+++ b/docs/contracts/v3/guides/providing-liquidity/decrease-liquidity.md
@@ -39,7 +39,7 @@ Here we decrease the liquidity of our position without withdrawing all of it.
 
         (amount0, amount1) = nonfungiblePositionManager.decreaseLiquidity(params);
 
-        INonfungiblePositionManager.CollectParams memory params =
+        INonfungiblePositionManager.CollectParams memory collectParams =
             INonfungiblePositionManager.CollectParams({
                 tokenId: tokenId,
                 recipient: address(this),
@@ -47,7 +47,7 @@ Here we decrease the liquidity of our position without withdrawing all of it.
                 amount1Max: amount1
             });
 
-        (collectedAmount0, collectedAmount1) = nonfungiblePositionManager.collect(params);
+        (collectedAmount0, collectedAmount1) = nonfungiblePositionManager.collect(collectParams);
 
         // send liquidity back to owner
         _sendToOwner(tokenId, collectedAmount0, collectedAmount1);

--- a/docs/contracts/v3/guides/providing-liquidity/decrease-liquidity.md
+++ b/docs/contracts/v3/guides/providing-liquidity/decrease-liquidity.md
@@ -39,8 +39,18 @@ Here we decrease the liquidity of our position without withdrawing all of it.
 
         (amount0, amount1) = nonfungiblePositionManager.decreaseLiquidity(params);
 
-        //send liquidity back to owner
-        _sendToOwner(tokenId, amount0, amount1);
+        INonfungiblePositionManager.CollectParams memory params =
+            INonfungiblePositionManager.CollectParams({
+                tokenId: tokenId,
+                recipient: address(this),
+                amount0Max: amount0,
+                amount1Max: amount1
+            });
+
+        (collectedAmount0, collectedAmount1) = nonfungiblePositionManager.collect(params);
+
+        // send liquidity back to owner
+        _sendToOwner(tokenId, collectedAmount0, collectedAmount1);
     }
 ```
 


### PR DESCRIPTION
Decrease liquidity example never calls the `collect` method, so at that point the contract doesn't have enough tokens to send to the owner since the funds are still at the `Pool` contract. Either `_sendToOwner` call should be removed or `collect` should be called before calling the `_sendToOwner`.
I've added a call to `collect` before calling the `_sendToOwner`.
This has caused us almost a day of development unfortunately.

Closes #389 