### PR TITLE
Corrects a typo in the 02-trading-from-a-smart-contract.md file

### DIFF
--- a/docs/contracts/v2/guides/smart-contract-integration/02-trading-from-a-smart-contract.md
+++ b/docs/contracts/v2/guides/smart-contract-integration/02-trading-from-a-smart-contract.md
@@ -56,4 +56,4 @@ Because Ethereum transactions occur in an adversarial environment, smart contrac
 
 The best way to protect against these attacks is to use an external price feed or "price oracle". The best "oracle" is simply _traders' off-chain observation of the current price_, which can be passed into the trade as a safety check. This strategy is best for situations _where users initiate trades on their own behalf_.
 
-However, when an off-chain price can't be used, an on-chain oracle should be used instead. Determining the best oracle for a given situation is a not part of this guide, but for more details on the Uniswap V2 approach to oracles, see [Oracles](../../concepts/core-concepts/oracles).
+However, when an off-chain price can't be used, an on-chain oracle should be used instead. Determining the best oracle for a given situation is not part of this guide, but for more details on the Uniswap V2 approach to oracles, see [Oracles](../../concepts/core-concepts/oracles).


### PR DESCRIPTION
Changes "is a not part of this guide" to "is not part of this guide"