### PR TITLE
fix: Escape asterisk in unordered nonce section

### DIFF
--- a/docs/contracts/permit2/reference/signature-transfer.md
+++ b/docs/contracts/permit2/reference/signature-transfer.md
@@ -209,7 +209,7 @@ It’s important to note that when hashing multiple typed structs, the ordering 
 
 Instead of using incrementing nonces, we introduce non-monotonic, or unordered nonces with a `nonceBitmap`. 
 
-The `nonceBitmap` maps an owner's address to a uint248 value, which we will call `wordPos` which is the index of the desired bitmap. There are 2**248 possible indices and this 2**248 possible bitmaps where each bitmap holds 256 bits. A bit must be flipped on to prevent replays of users’ signatures. Bits that are dirtied may not be used again.
+The `nonceBitmap` maps an owner's address to a uint248 value, which we will call `wordPos` which is the index of the desired bitmap. There are 2\**248 possible indices and this 2\**248 possible bitmaps where each bitmap holds 256 bits. A bit must be flipped on to prevent replays of users’ signatures. Bits that are dirtied may not be used again.
 
 ```solidity
 // nonceBitmap[ownerAddress][wordPosition] retrieves a uint256 bitmap

--- a/docs/contracts/permit2/reference/signature-transfer.md
+++ b/docs/contracts/permit2/reference/signature-transfer.md
@@ -209,7 +209,7 @@ It’s important to note that when hashing multiple typed structs, the ordering 
 
 Instead of using incrementing nonces, we introduce non-monotonic, or unordered nonces with a `nonceBitmap`. 
 
-The `nonceBitmap` maps an owner's address to a uint248 value, which we will call `wordPos` which is the index of the desired bitmap. There are 2\**248 possible indices and this 2\**248 possible bitmaps where each bitmap holds 256 bits. A bit must be flipped on to prevent replays of users’ signatures. Bits that are dirtied may not be used again.
+The `nonceBitmap` maps an owner's address to a uint248 value, which we will call `wordPos` which is the index of the desired bitmap. There are 2\**248 possible indices and this results in 2\**248 possible bitmaps where each bitmap holds 256 bits. A bit must be flipped on to prevent replays of users’ signatures. Bits that are dirtied may not be used again.
 
 ```solidity
 // nonceBitmap[ownerAddress][wordPosition] retrieves a uint256 bitmap


### PR DESCRIPTION
Regarding unordered nonce there is a documentation fragment that is also confusing:
https://docs.uniswap.org/contracts/permit2/reference/signature-transfer#nonce-schema
"...There are 2248 possible indices and this 2248 possible bitmaps..."
it should read as  "... 2^248 possible indices and this results in 2^248 possible bitmaps..." but was damaged by markup.
