### PR TITLE
Add web3.py to the list of alternate web3 libraries

### DIFF
--- a/docs/sdk/v3/guides/02-local-development.md
+++ b/docs/sdk/v3/guides/02-local-development.md
@@ -92,7 +92,7 @@ POST `http://127.0.0.1:8545`
 
 Body:
 
-```JSON
+```json
 {
     "jsonrpc": "2.0",
     "method": "eth_chainId",
@@ -103,7 +103,7 @@ Body:
 
 The result should look like the below (see image below as well):
 
-```JSON
+```json
 {
     "jsonrpc": "2.0",
     "id": 1,

--- a/docs/sdk/v3/guides/03-web3-development-basics.md
+++ b/docs/sdk/v3/guides/03-web3-development-basics.md
@@ -91,6 +91,7 @@ Web3 development is not limited to JS. Web3 libraries for various languages incl
 * [KEthereum](https://github.com/komputing/KEthereum) - Kotlin SDK for Android development.
 * [ethers-rs](https://github.com/gakonst/ethers-rs) - Rust SDK.
 * [ethclient](https://github.com/ethereum/go-ethereum/tree/master/ethclient) - Go SDK, part of geth, the reference Ethereum node implementation.
+* [web3.py](https://github.com/ethereum/web3.py) - Python SDK.
 
 At the moment, Uniswap only offers Typescript sdks.
 


### PR DESCRIPTION
The JSON in `local-development.md` wasn't showing up in color, so lower-casing `json` aims to fix that. See screenshot: 
<img width="785" alt="image" src="https://github.com/Uniswap/docs/assets/6540608/cea4b987-b6fe-4ad8-8abf-75dae3c2d8f0">

Also added web3.py to the list of alternate web3 sdks :)