### PR TITLE
Specified names to import individually [no-global-import]

### DIFF
--- a/docs/contracts/v3/guides/swaps/single-swaps.md
+++ b/docs/contracts/v3/guides/swaps/single-swaps.md
@@ -33,8 +33,8 @@ pragma abicoder v2;
 Import the two relevant contracts from the npm package installation
 
 ```solidity
-import '@uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol';
-import '@uniswap/v3-periphery/contracts/libraries/TransferHelper.sol';
+import { safeTransferFrom, safeApprove, safeTransfer, TransferHelper } from '@uniswap/v3-periphery/contracts/libraries/TransferHelper.sol';
+import { ISwapRouter } from '@uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol';
 ```
 
 Create a contract called `SwapExamples`, and declare an immutable public variable `swapRouter` of type `ISwapRouter`.
@@ -181,8 +181,8 @@ function swapExactOutputSingle(uint256 amountOut, uint256 amountInMaximum) exter
 pragma solidity =0.7.6;
 pragma abicoder v2;
 
-import '@uniswap/v3-periphery/contracts/libraries/TransferHelper.sol';
-import '@uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol';
+import { safeTransferFrom, safeApprove, safeTransfer, TransferHelper } from '@uniswap/v3-periphery/contracts/libraries/TransferHelper.sol';
+import { ISwapRouter } from '@uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol';
 
 contract SwapExamples {
     // For the scope of these swap examples,


### PR DESCRIPTION
# Enhancement:
```
Linter: global import of path @uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol should not be allowed. Instead specified the names to import individually [no-global-import]
```