### PR TITLE
Bug: Fix broken link for "Fetch token prices"

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -74,7 +74,7 @@ export const dAppGuides = [
   {
     title: 'Fetch token prices',
     text: 'Fetch the price of tokens in a specific Pool',
-    to: 'sdk/v3/guides/quoting',
+    to: 'sdk/v3/guides/swaps/quoting',
   },
   {
     title: 'Create a Trade',


### PR DESCRIPTION
The quoting link didn't get updated with the new swaps path. Updated path to fix broken link