### PR TITLE
Fix: Broken links to the locking mechanism page

### DIFF
--- a/docs/contracts/v4/concepts/03-managing-position.mdx
+++ b/docs/contracts/v4/concepts/03-managing-position.mdx
@@ -134,7 +134,7 @@ modifyPositionRouter.modifyPosition(
 Note: `PoolModifyPositionTest` implements the `ILockCallback` interface and adds the `lockAcquired` function, which in turn calls the `manager.modifyPosition` function.
 
 # Acquiring Lock
-Full detail about the locking mechanism is explained in the [Locking Mechanism](/03_Locking_Mechanism/README.md) section.
+Full detail about the locking mechanism is explained in the [Locking Mechanism](05-lock-mechanism.mdx) section.
 
 The contract that calls the `modifyPosition` must implement ILockCallback interface.
 

--- a/docs/contracts/v4/concepts/04-swap-tokens.mdx
+++ b/docs/contracts/v4/concepts/04-swap-tokens.mdx
@@ -60,7 +60,7 @@ swapRouter.swap(key, params, testSettings, hookData);
 Note: `PoolSwapTest` implements the `ILockCallback` interface and adds the `lockAcquired` function, which in turn calls the `manager.swap` function.
 
 # Acquiring Lock
-Full detail about the locking mechanism is explained in the [Locking Mechanism](/03_Locking_Mechanism/README.md) section.
+Full detail about the locking mechanism is explained in the [Locking Mechanism](05-lock-mechanism.mdx) section.
 
 The contract that calls the `swap` must implement ILockCallback interface.
 


### PR DESCRIPTION
Fixes the broken links to the Locking Mechanism section on these pages:

https://docs.uniswap.org/contracts/v4/concepts/managing-positions
https://docs.uniswap.org/contracts/v4/concepts/swap-tokens