### PR TITLE
Update: Subgraph API links

### DIFF
--- a/docs/contracts/v2/guides/interface-integration/01-using-the-api.md
+++ b/docs/contracts/v2/guides/interface-integration/01-using-the-api.md
@@ -46,7 +46,7 @@ import { HttpLink } from 'apollo-link-http'
 
 export const client = new ApolloClient({
   link: new HttpLink({
-    uri: 'https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v2',
+    uri: 'https://api.thegraph.com/subgraphs/name/ianlapham/uniswap-v2-dev',
   }),
   cache: new InMemoryCache(),
 })
@@ -195,7 +195,7 @@ import gql from 'graphql-tag'
 
 export const client = new ApolloClient({
   link: new HttpLink({
-    uri: 'https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v2',
+    uri: 'https://api.thegraph.com/subgraphs/name/ianlapham/uniswap-v2-dev',
   }),
   fetchOptions: {
     mode: 'no-cors',


### PR DESCRIPTION
Update for the subgraph links. replacing the old subgraph that crashed.

https://linear.app/uniswap/issue/CX-519/uniswap-document-updatesissues-to-repair

<img width="1139" alt="Using_the_API___Uniswap" src="https://github.com/Uniswap/docs/assets/60412342/a0c4d85a-976e-41b9-9737-4c30b376f6fb">

<img width="1159" alt="Using_the_API___Uniswap" src="https://github.com/Uniswap/docs/assets/60412342/acaf7773-93dc-4e61-b869-3fbcf29fcce6">
