### PR TITLE
Add warning about non-zero sqrtPriceLimitX96

### DIFF
--- a/docs/contracts/v3/guides/swaps/single-swaps.md
+++ b/docs/contracts/v3/guides/swaps/single-swaps.md
@@ -102,7 +102,9 @@ A brief overview of the parameters:
 - `recipient` the destination address of the outbound token
 - `deadline`: the unix time after which a swap will fail, to protect against long-pending transactions and wild swings in prices
 - `amountOutMinimum`: we are setting to zero, but this is a significant risk in production. For a real deployment, this value should be calculated using our SDK or an onchain price oracle - this helps protect against getting an unusually bad price for a trade due to a front running sandwich or another type of price manipulation
-- `sqrtPriceLimitX96`: We set this to zero - which makes this parameter inactive. In production, this value can be used to set the limit for the price the swap will push the pool to, which can help protect against price impact or for setting up logic in a variety of price-relevant mechanisms.
+- `sqrtPriceLimitX96`: We set this to zero - which makes this parameter inactive. In production, this value can be used to set the limit for the price the swap will push the pool to, which can help protect against price impact or for setting up logic in a variety of price-relevant mechanisms. 
+
+  **WARNING: Passing in a non-zero `sqrtPriceLimitX96` can mean that less tokens that the amount specified by `amountIn` are swapped**. Any contract that uses a non-zero `sqrtPriceLimitX96` parameter will need to refund any unswapped tokens. 
 
 ### Call the function
 


### PR DESCRIPTION
A common integration error is to pass in a non-zero `sqrtPriceLimitX96` value and then not refund the user the unswapped tokens.

Highlighting this in the documentation, or even providing a more complex example in this doc, will be extremely useful to developers wishing to integrate with Uniswap V3. 

e.g.

```solidity
contract SomeContract {

    // ...

    function swapExactInputSingle(uint256 amountIn, uint160 sqrtPriceLimitX96) external returns (uint256 amountOut) {
        // msg.sender must approve this contract
        // Transfer the specified amount of DAI to this contract.
        TransferHelper.safeTransferFrom(DAI, msg.sender, address(this), amountIn);
        // Approve the router to spend DAI.
        TransferHelper.safeApprove(DAI, address(swapRouter), amountIn);
        // Naively set amountOutMinimum to 0. In production, use an oracle or other data source to choose a safer value for amountOutMinimum.
        // We also set the sqrtPriceLimitx96 to be 0 to ensure we swap our exact input amount.
        ISwapRouter.ExactInputSingleParams memory params =
            ISwapRouter.ExactInputSingleParams({
                tokenIn: DAI,
                tokenOut: WETH9,
                fee: poolFee,
                recipient: msg.sender,
                deadline: block.timestamp,
                amountIn: amountIn,
                amountOutMinimum: 0,
                sqrtPriceLimitX96: sqrtPriceLimitX96
            });
        // The call to `exactInputSingle` executes the swap.
        amountOut = swapRouter.exactInputSingle(params);
        
        // ***ERROR***: Less than amountIn token may have been swapped. They need to be refunded to the user! 
    }

    // ....

}
```