### PR TITLE
Fixed a broken link on 01-overview.md

### DIFF
--- a/docs/concepts/governance/01-overview.md
+++ b/docs/concepts/governance/01-overview.md
@@ -9,7 +9,7 @@ title: Overview
 
 ## Documentation
 
-For reference material on the Uniswap Governance system please see [Governance Reference](../../../contracts/v3/reference/governance/overview.md).
+For reference material on the Uniswap Governance system please see [Governance Reference](../../contracts/v3/reference/governance/overview.md).
 
 ## UNI Address
 


### PR DESCRIPTION
Fixed the link to "Governance Reference" under "Documentation".