### PR TITLE
Fix: Ethereum spelling errors, OP Sepolia chain ID, and Blast chain ID

### DIFF
--- a/docs/contracts/v2/reference/smart-contracts/08-deployment-addresses.md
+++ b/docs/contracts/v2/reference/smart-contracts/08-deployment-addresses.md
@@ -10,7 +10,7 @@ Contract addresses for the [`Uniswap V2 Factory`](https://github.com/Uniswap/v2-
 | Network                                              | Factory Contract Address                     | V2Router02 Contract Address                  |
 | ---------------------------------------------------- | -------------------------------------------- | -------------------------------------------- |
 | Mainnet                                              | `0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f` | `0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D` |
-| Etherum Sepolia                                      | `0xB7f907f7A9eBC822a80BD25E224be42Ce0A698A0` | `0x425141165d3DE9FEC831896C016617a52363b687` |
+| Ethereum Sepolia                                     | `0xB7f907f7A9eBC822a80BD25E224be42Ce0A698A0` | `0x425141165d3DE9FEC831896C016617a52363b687` |
 | Arbitrum                                             | `0xf1D7CC64Fb4452F05c498126312eBE29f30Fbcf9` | `0x4752ba5dbc23f44d87826276bf6fd6b1c372ad24` |
 | Avalanche                                            | `0x9e5A52f57b3038F1B8EeE45F28b3C1967e22799C` | `0x4752ba5dbc23f44d87826276bf6fd6b1c372ad24` |
 | BNB Chain                                            | `0x8909Dc15e40173Ff4699343b6eB8132c65e18eC6` | `0x4752ba5dbc23f44d87826276bf6fd6b1c372ad24` |

--- a/docs/contracts/v3/reference/deployments/Blast-Deployments.md
+++ b/docs/contracts/v3/reference/deployments/Blast-Deployments.md
@@ -50,6 +50,6 @@ getPool("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "0xc02aaa39b223fe8d0a0e5c4
 
 The Uniswap Protocol supports trading of ERC20 tokens. In order to swap a native asset like ETH (or MATIC on Polygon), the Uniswap protocol wraps these assets in an ERC20 wrapped native token contract. The protocol uses the following WETH9 addresses on Ethereum and WMATIC addresses on Polygon.
 
-| Network | ChainId  | Wrapped Native Token | Address                                      |
-| ------- | -------- | -------------------- | -------------------------------------------- |
-| Blast   | `1`      | WETH                 | `0x4300000000000000000000000000000000000004` |
+| Network | ChainId | Wrapped Native Token | Address                                      |
+| ------- | ------- | -------------------- | -------------------------------------------- |
+| Blast   | `81457` | WETH                 | `0x4300000000000000000000000000000000000004` |

--- a/docs/contracts/v3/reference/deployments/Optimism-Deployments.md
+++ b/docs/contracts/v3/reference/deployments/Optimism-Deployments.md
@@ -55,7 +55,7 @@ getPool("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "0xc02aaa39b223fe8d0a0e5c4
 
 The Uniswap Protocol supports trading of ERC20 tokens. In order to swap a native asset like ETH (or MATIC on Polygon), the Uniswap protocol wraps these assets in an ERC20 wrapped native token contract. The protocol uses the following WETH9 addresses on Ethereum and WMATIC addresses on Polygon.
 
-| Network             | ChainId  | Wrapped Native Token | Address                                      |
-| ------------------- | -------- | -------------------- | -------------------------------------------- |
-| Optimism            | `10`     | WETH                 | `0x4200000000000000000000000000000000000006` |
-| Optimism Sepolia    | `137`    | WETH                 | `0x4200000000000000000000000000000000000006` |
+| Network             | ChainId    | Wrapped Native Token | Address                                      |
+| ------------------- | ---------- | -------------------- | -------------------------------------------- |
+| Optimism            | `10`       | WETH                 | `0x4200000000000000000000000000000000000006` |
+| Optimism Sepolia    | `11155420` | WETH                 | `0x4200000000000000000000000000000000000006` |

--- a/docs/contracts/v3/reference/deployments/deployments.md
+++ b/docs/contracts/v3/reference/deployments/deployments.md
@@ -9,7 +9,7 @@ The Uniswap Protocol is made up of multiple contracts on many networks.
 
 Please do not assume contracts are deployed to the same addresses across chains, and be extremely careful to confirm addresses before using a contract.
 
-- [`Etherum`](./Ethereum-Deployments.md)
+- [`Ethereum`](./Ethereum-Deployments.md)
 - [`Arbitrum`](./Arbitrum-Deployments.md)
 - [`Optimism`](./Optimism-Deployments.md)
 - [`Polygon`](./Polygon-Deployments.md)


### PR DESCRIPTION
fix: Ethereum spelling errors, OP Sepolia chain ID, and Blast chain ID

Fixes: 
https://github.com/Uniswap/docs/pull/698
https://github.com/Uniswap/docs/pull/696
https://github.com/Uniswap/docs/pull/695