### PR TITLE
Typo: Inheritance-constructors.md

### DIFF
--- a/docs/contracts/v3/guides/flash-integrations/Inheritance-constructors.md
+++ b/docs/contracts/v3/guides/flash-integrations/Inheritance-constructors.md
@@ -46,7 +46,7 @@ contract PairFlash is IUniswapV3FlashCallback, PeripheryPayments {
 Declare an immutable public variable `swapRouter` of type `ISwapRouter`:
 
 ```solidity
-    ISwapRouter public Immutable swapRouter;
+    ISwapRouter public immutable swapRouter;
 ```
 
 Declare the constructor here, which is executed once when the contract is deployed. Our constructor hardcodes the address of the V3 router, factory, and the address of weth9, the [ERC-20 wrapper](https://weth.io/) for ether.


### PR DESCRIPTION
Corrects the capitalisation of `immutable` when declaring `swapRouter` in the [inheriting-the-v3-contracts](https://docs.uniswap.org/contracts/v3/guides/flash-integrations/inheritance-constructors#inheriting-the-v3-contracts) section.