### PR TITLE
fix: accidental Markdown usage in Nonce Schema section of permit2 docs

### DIFF
--- a/docs/contracts/permit2/reference/signature-transfer.md
+++ b/docs/contracts/permit2/reference/signature-transfer.md
@@ -209,7 +209,7 @@ It’s important to note that when hashing multiple typed structs, the ordering 
 
 Instead of using incrementing nonces, we introduce non-monotonic, or unordered nonces with a `nonceBitmap`. 
 
-The `nonceBitmap` maps an owner's address to a uint248 value, which we will call `wordPos` which is the index of the desired bitmap. There are 2**248 possible indices and this 2**248 possible bitmaps where each bitmap holds 256 bits. A bit must be flipped on to prevent replays of users’ signatures. Bits that are dirtied may not be used again.
+The `nonceBitmap` maps an owner's address to a `uint248` value, which we will call `wordPos` which is the index of the desired bitmap. There are 2\*\*248 possible indices and thus 2\*\*248 possible bitmaps where each bitmap holds 256 bits. A bit must be flipped on to prevent replays of users’ signatures. Bits that are dirtied may not be used again.
 
 ```solidity
 // nonceBitmap[ownerAddress][wordPosition] retrieves a uint256 bitmap


### PR DESCRIPTION
The Nonce Schema section of the permit2 docs refers to the number 2 to the power of 248; however representing this as `2**248` twice within the same sentence inadvertently triggering Markdown's mechanism for bold text.  So escape the `**` characters to avoid this bold formatting.

Also fix a "this" / "thus" typo, and make a `uint248` monospace for consistency.