### PR TITLE
fix: update url to collection of templates for v4 hooks

### DIFF
--- a/docs/contracts/v4/first-hook/01-building-you-hook.mdx
+++ b/docs/contracts/v4/first-hook/01-building-you-hook.mdx
@@ -11,7 +11,7 @@ that can make the setup process easier. Similarly, when building your own hooks,
 2) Using a router which acquire the lock and then call various functions on the pool manager
 3) Deploying the hook to a deterministic address
 
-Many of these steps are already taken care by a few template repositories which are listed [here](https://uniswaphooks.com/components/hooks/templates)
+Many of these steps are already taken care by a few template repositories which are listed [here](https://uniswaphooks.com/hooks/collection/templates)
 
 ## Hooks Template
 One of the most popular templates is the [v4-template](https://github.com/uniswapfoundation/v4-template) which is


### PR DESCRIPTION
I was reading the documentation to start exploring different use-cases of v4 hooks and found a 404 error for the templates URL. 