### PR TITLE
Update tickToWord to use compressed variable

### DIFF
--- a/docs/sdk/v3/guides/advanced/02-pool-data.md
+++ b/docs/sdk/v3/guides/advanced/02-pool-data.md
@@ -211,7 +211,7 @@ function tickToWord(tick: number): number {
   if (tick < 0 && tick % tickSpacing !== 0) {
     compressed -= 1
   }
-  return tick >> 8
+  return compressed >> 8
 }
 
 const minWord = tickToWord(-887272)


### PR DESCRIPTION
Hi. I believe there's an issue in `tickToWord` function; it should be using the variable `compressed` instead.