### PR TITLE
docs: fix formatting on signature-transfer.md

### DIFF
--- a/docs/contracts/permit2/reference/signature-transfer.md
+++ b/docs/contracts/permit2/reference/signature-transfer.md
@@ -209,7 +209,7 @@ It’s important to note that when hashing multiple typed structs, the ordering 
 
 Instead of using incrementing nonces, we introduce non-monotonic, or unordered nonces with a `nonceBitmap`. 
 
-The `nonceBitmap` maps an owner's address to a uint248 value, which we will call `wordPos` which is the index of the desired bitmap. There are 2<sup>248</sup> possible indices and this 2<sup>248</sup> possible bitmaps where each bitmap holds 256 bits. A bit must be flipped on to prevent replays of users’ signatures. Bits that are dirtied may not be used again.
+The `nonceBitmap` maps an owner's address to a uint248 value, which we will call `wordPos` which is the index of the desired bitmap. There are 2<sup>248</sup> possible indices thus 2<sup>248</sup> possible bitmaps where each bitmap holds 256 bits. A bit must be flipped on to prevent replays of users’ signatures. Bits that are dirtied may not be used again.
 
 ```solidity
 // nonceBitmap[ownerAddress][wordPosition] retrieves a uint256 bitmap

--- a/docs/contracts/permit2/reference/signature-transfer.md
+++ b/docs/contracts/permit2/reference/signature-transfer.md
@@ -209,7 +209,7 @@ It’s important to note that when hashing multiple typed structs, the ordering 
 
 Instead of using incrementing nonces, we introduce non-monotonic, or unordered nonces with a `nonceBitmap`. 
 
-The `nonceBitmap` maps an owner's address to a uint248 value, which we will call `wordPos` which is the index of the desired bitmap. There are 2**248 possible indices and this 2**248 possible bitmaps where each bitmap holds 256 bits. A bit must be flipped on to prevent replays of users’ signatures. Bits that are dirtied may not be used again.
+The `nonceBitmap` maps an owner's address to a uint248 value, which we will call `wordPos` which is the index of the desired bitmap. There are 2<sup>248</sup> possible indices and this 2<sup>248</sup> possible bitmaps where each bitmap holds 256 bits. A bit must be flipped on to prevent replays of users’ signatures. Bits that are dirtied may not be used again.
 
 ```solidity
 // nonceBitmap[ownerAddress][wordPosition] retrieves a uint256 bitmap


### PR DESCRIPTION
This PR is to fix the markdown syntax for `signature-transfer.md` on Permit2.

Previously the double asterisk(2**248) accidentally bolded 248 instead of properly displaying it as 2 to the power of 248.