### PR TITLE
Update Sepolia ETH v2 contracts

### DIFF
--- a/docs/contracts/v2/reference/smart-contracts/08-deployment-addresses.md
+++ b/docs/contracts/v2/reference/smart-contracts/08-deployment-addresses.md
@@ -10,7 +10,7 @@ Contract addresses for the [`Uniswap V2 Factory`](https://github.com/Uniswap/v2-
 | Network                                              | Factory Contract Address                     | V2Router02 Contract Address                  |
 | ---------------------------------------------------- | -------------------------------------------- | -------------------------------------------- |
 | Mainnet                                              | `0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f` | `0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D` |
-| Sepolia                                              | `0xB7f907f7A9eBC822a80BD25E224be42Ce0A698A0` | `0x53544492C78D478294B5b1Fb8059a5D6C9aBBC67` |
+| Sepolia                                              | `0xF62c03E08ada871A0bEb309762E260a7a6a880E6` | `0xeE567Fe1712Faf6149d80dA1E6934E354124CfE3` |
 | Arbitrum                                             | `0xf1D7CC64Fb4452F05c498126312eBE29f30Fbcf9` | `0x4752ba5dbc23f44d87826276bf6fd6b1c372ad24` |
 | Avalanche                                            | `0x9e5A52f57b3038F1B8EeE45F28b3C1967e22799C` | `0x4752ba5dbc23f44d87826276bf6fd6b1c372ad24` |
 | BNB Chain                                            | `0x8909Dc15e40173Ff4699343b6eB8132c65e18eC6` | `0x4752ba5dbc23f44d87826276bf6fd6b1c372ad24` |


### PR DESCRIPTION
These contract have been relaunched due to issues with init hash and bytes of the factory contract