### PR TITLE
Increase height of Uniswap Widget to match actual height of iframe contents

### DIFF
--- a/docs/sdk/swap-widget/guides/swap-widget.mdx
+++ b/docs/sdk/swap-widget/guides/swap-widget.mdx
@@ -16,7 +16,7 @@ Here’s a live preview of the swap widget.
 
 <iframe
   width="376"
-  height="376"
+  height="438"
   scrolling="no"
   src="https://widgets-uniswap.vercel.app/_renderer.html?_fixtureId=%7B%22path%22%3A%22src%2Fcosmos%2FSwap.fixture.tsx%22%2C%22name%22%3Anull%7D"
 ></iframe>


### PR DESCRIPTION
Before:

<img width="467" alt="Before" src="https://github.com/user-attachments/assets/f84d0641-c4cb-42e4-b7c9-eab05c474741">

After:

<img width="446" alt="After" src="https://github.com/user-attachments/assets/aa90a46f-7954-4824-8fb9-e6ca69d9f314">

