### PR TITLE
Remove unused "deadline" parameter

### DIFF
--- a/docs/contracts/v3/guides/swaps/single-swaps.md
+++ b/docs/contracts/v3/guides/swaps/single-swaps.md
@@ -100,7 +100,6 @@ A brief overview of the parameters:
 - `tokenOut` The contract address of the outbound token
 - `fee` The fee tier of the pool, used to determine the correct pool contract in which to execute the swap
 - `recipient` the destination address of the outbound token
-- `deadline`: the unix time after which a swap will fail, to protect against long-pending transactions and wild swings in prices
 - `amountOutMinimum`: we are setting to zero, but this is a significant risk in production. For a real deployment, this value should be calculated using our SDK or an onchain price oracle - this helps protect against getting an unusually bad price for a trade due to a front running sandwich or another type of price manipulation
 - `sqrtPriceLimitX96`: We set this to zero - which makes this parameter inactive. In production, this value can be used to set the limit for the price the swap will push the pool to, which can help protect against price impact or for setting up logic in a variety of price-relevant mechanisms.
 
@@ -115,7 +114,6 @@ A brief overview of the parameters:
                 tokenOut: WETH9,
                 fee: poolFee,
                 recipient: msg.sender,
-                deadline: block.timestamp,
                 amountIn: amountIn,
                 amountOutMinimum: 0,
                 sqrtPriceLimitX96: 0
@@ -155,7 +153,6 @@ function swapExactOutputSingle(uint256 amountOut, uint256 amountInMaximum) exter
                 tokenOut: WETH9,
                 fee: poolFee,
                 recipient: msg.sender,
-                deadline: block.timestamp,
                 amountOut: amountOut,
                 amountInMaximum: amountInMaximum,
                 sqrtPriceLimitX96: 0
@@ -229,7 +226,6 @@ contract SwapExamples {
                 tokenOut: WETH9,
                 fee: poolFee,
                 recipient: msg.sender,
-                deadline: block.timestamp,
                 amountIn: amountIn,
                 amountOutMinimum: 0,
                 sqrtPriceLimitX96: 0
@@ -259,7 +255,6 @@ contract SwapExamples {
                 tokenOut: WETH9,
                 fee: poolFee,
                 recipient: msg.sender,
-                deadline: block.timestamp,
                 amountOut: amountOut,
                 amountInMaximum: amountInMaximum,
                 sqrtPriceLimitX96: 0


### PR DESCRIPTION
The "deadline" parameter present in documentation for v3 single swaps is not part of the actual contract interface for the v3 swap router: 

Example: https://basescan.org/address/0x2626664c2603336E57B271c5C0b26F421741e481#writeProxyContract#F7