### PR TITLE
incorrect copy in WETH/Wrapped deployments description

### DIFF
--- a/docs/contracts/v3/reference/deployments/AVAX-Deployments.md
+++ b/docs/contracts/v3/reference/deployments/AVAX-Deployments.md
@@ -52,7 +52,7 @@ getPool("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "0xc02aaa39b223fe8d0a0e5c4
 
 # Wrapped Native Token Addresses
 
-The Uniswap Protocol supports trading of ERC20 tokens. In order to swap a native asset like ETH (or MATIC on Polygon), the Uniswap protocol wraps these assets in an ERC20 wrapped native token contract. The protocol uses the following WETH9 addresses on Ethereum and WMATIC addresses on Polygon.
+The Uniswap Protocol supports trading of ERC20 tokens. In order to swap a native asset like ETH (or AVAX on Avalanche), the Uniswap protocol wraps these assets in an ERC20 wrapped native token contract. The protocol uses the following WAVAX address on Avalanche.
 
 | Network | ChainId  | Wrapped Native Token | Address                                      |
 | ------- | -------- | -------------------- | -------------------------------------------- |

--- a/docs/contracts/v3/reference/deployments/Arbitrum-Deployments.md
+++ b/docs/contracts/v3/reference/deployments/Arbitrum-Deployments.md
@@ -53,7 +53,7 @@ getPool("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "0xc02aaa39b223fe8d0a0e5c4
 
 # Wrapped Native Token Addresses
 
-The Uniswap Protocol supports trading of ERC20 tokens. In order to swap a native asset like ETH (or MATIC on Polygon), the Uniswap protocol wraps these assets in an ERC20 wrapped native token contract. The protocol uses the following WETH9 addresses on Ethereum and WMATIC addresses on Polygon.
+The Uniswap Protocol supports trading of ERC20 tokens. In order to swap a native asset like ETH (or MATIC on Polygon), the Uniswap protocol wraps these assets in an ERC20 wrapped native token contract. The protocol uses the following WETH addresses on Arbitrum and Arbitrum Sepolia.
 
 | Network             | ChainId  | Wrapped Native Token | Address                                      |
 | ------------------- | -------- | -------------------- | -------------------------------------------- |

--- a/docs/contracts/v3/reference/deployments/BNB-Binance-Deployments.md
+++ b/docs/contracts/v3/reference/deployments/BNB-Binance-Deployments.md
@@ -51,7 +51,7 @@ getPool("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "0xc02aaa39b223fe8d0a0e5c4
 
 # Wrapped Native Token Addresses
 
-The Uniswap Protocol supports trading of ERC20 tokens. In order to swap a native asset like ETH (or MATIC on Polygon), the Uniswap protocol wraps these assets in an ERC20 wrapped native token contract. The protocol uses the following WETH9 addresses on Ethereum and WMATIC addresses on Polygon.
+The Uniswap Protocol supports trading of ERC20 tokens. In order to swap a native asset like ETH (or BNB on BSC), the Uniswap protocol wraps these assets in an ERC20 wrapped native token contract. The protocol uses the following WBNB address on Binance Smart Chain.
 
 | Network             | ChainId  | Wrapped Native Token | Address                                      |
 | ------------------- | -------- | -------------------- | -------------------------------------------- |

--- a/docs/contracts/v3/reference/deployments/Base-Deployments.md
+++ b/docs/contracts/v3/reference/deployments/Base-Deployments.md
@@ -51,7 +51,7 @@ getPool("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "0xc02aaa39b223fe8d0a0e5c4
 
 # Wrapped Native Token Addresses
 
-The Uniswap Protocol supports trading of ERC20 tokens. In order to swap a native asset like ETH (or MATIC on Polygon), the Uniswap protocol wraps these assets in an ERC20 wrapped native token contract. The protocol uses the following WETH9 addresses on Ethereum and WMATIC addresses on Polygon.
+The Uniswap Protocol supports trading of ERC20 tokens. In order to swap a native asset like ETH (or MATIC on Polygon), the Uniswap protocol wraps these assets in an ERC20 wrapped native token contract. The protocol uses the following WETH addresses on Base and Base Sepolia.
 
 | Network             | ChainId  | Wrapped Native Token | Address                                      |
 | ------------------- | -------- | -------------------- | -------------------------------------------- |

--- a/docs/contracts/v3/reference/deployments/Blast-Deployments.md
+++ b/docs/contracts/v3/reference/deployments/Blast-Deployments.md
@@ -48,7 +48,7 @@ getPool("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "0xc02aaa39b223fe8d0a0e5c4
 
 # Wrapped Native Token Addresses
 
-The Uniswap Protocol supports trading of ERC20 tokens. In order to swap a native asset like ETH (or MATIC on Polygon), the Uniswap protocol wraps these assets in an ERC20 wrapped native token contract. The protocol uses the following WETH9 addresses on Ethereum and WMATIC addresses on Polygon.
+The Uniswap Protocol supports trading of ERC20 tokens. In order to swap a native asset like ETH (or MATIC on Polygon), the Uniswap protocol wraps these assets in an ERC20 wrapped native token contract. The protocol uses the following WETH address on Blast.
 
 | Network | ChainId | Wrapped Native Token | Address                                      |
 | ------- | ------- | -------------------- | -------------------------------------------- |

--- a/docs/contracts/v3/reference/deployments/Celo-Deployments.md
+++ b/docs/contracts/v3/reference/deployments/Celo-Deployments.md
@@ -51,7 +51,7 @@ getPool("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "0xc02aaa39b223fe8d0a0e5c4
 
 # CELO Native Asset
 
-The Uniswap Protocol supports trading of ERC20 tokens. In order to swap a native asset like ETH (or MATIC on Polygon), the Uniswap protocol wraps these assets in an ERC20 wrapped native token contract. The protocol uses the following WETH9 addresses on Ethereum and WMATIC addresses on Polygon.
+The Uniswap Protocol supports trading of ERC20 tokens. In order to swap a native asset like ETH (or CELO on Celo), the Uniswap protocol wraps these assets in an ERC20 wrapped native token contract. The protocol uses the following CELO address on Celo.
 
 **Note: CELO is the native asset, it is a token and will work as a token, needing approval for routers to manage.*
 

--- a/docs/contracts/v3/reference/deployments/Ethereum-Deployments.md
+++ b/docs/contracts/v3/reference/deployments/Ethereum-Deployments.md
@@ -54,7 +54,7 @@ getPool("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "0xc02aaa39b223fe8d0a0e5c4
 
 # Wrapped Native Token Addresses
 
-The Uniswap Protocol supports trading of ERC20 tokens. In order to swap a native asset like ETH (or MATIC on Polygon), the Uniswap protocol wraps these assets in an ERC20 wrapped native token contract. The protocol uses the following WETH9 addresses on Ethereum and WMATIC addresses on Polygon.
+The Uniswap Protocol supports trading of ERC20 tokens. In order to swap a native asset like ETH (or MATIC on Polygon), the Uniswap protocol wraps these assets in an ERC20 wrapped native token contract. The protocol uses the following WETH9 addresses on Ethereum and Sepolia.
 
 | Network             | ChainId     | Wrapped Native Token | Address                                      |
 | ------------------- | ----------- | -------------------- | -------------------------------------------- |

--- a/docs/contracts/v3/reference/deployments/Optimism-Deployments.md
+++ b/docs/contracts/v3/reference/deployments/Optimism-Deployments.md
@@ -53,7 +53,7 @@ getPool("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "0xc02aaa39b223fe8d0a0e5c4
 
 # Wrapped Native Token Addresses
 
-The Uniswap Protocol supports trading of ERC20 tokens. In order to swap a native asset like ETH (or MATIC on Polygon), the Uniswap protocol wraps these assets in an ERC20 wrapped native token contract. The protocol uses the following WETH9 addresses on Ethereum and WMATIC addresses on Polygon.
+The Uniswap Protocol supports trading of ERC20 tokens. In order to swap a native asset like ETH (or MATIC on Polygon), the Uniswap protocol wraps these assets in an ERC20 wrapped native token contract. The protocol uses the following WETH addresses on Optimism and Optimism Sepolia.
 
 | Network             | ChainId    | Wrapped Native Token | Address                                      |
 | ------------------- | ---------- | -------------------- | -------------------------------------------- |

--- a/docs/contracts/v3/reference/deployments/Polygon-Deployments.md
+++ b/docs/contracts/v3/reference/deployments/Polygon-Deployments.md
@@ -53,7 +53,7 @@ getPool("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "0xc02aaa39b223fe8d0a0e5c4
 
 # Wrapped Native Token Addresses
 
-The Uniswap Protocol supports trading of ERC20 tokens. In order to swap a native asset like ETH (or MATIC on Polygon), the Uniswap protocol wraps these assets in an ERC20 wrapped native token contract. The protocol uses the following WETH9 addresses on Ethereum and WMATIC addresses on Polygon.
+The Uniswap Protocol supports trading of ERC20 tokens. In order to swap a native asset like ETH (or POL on Polygon), the Uniswap protocol wraps these assets in an ERC20 wrapped native token contract. The protocol uses the following WMATIC addresses on Polygon and Polygon Mumbai.
 
 | Network             | ChainId  | Wrapped Native Token | Address                                      |
 | ------------------- | -------- | -------------------- | -------------------------------------------- |

--- a/docs/contracts/v3/reference/deployments/WorldChain-Deployments.md
+++ b/docs/contracts/v3/reference/deployments/WorldChain-Deployments.md
@@ -47,7 +47,7 @@ getPool("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "0xc02aaa39b223fe8d0a0e5c4
 
 # Wrapped Native Token Addresses
 
-The Uniswap Protocol supports trading of ERC20 tokens. In order to swap a native asset like ETH (or MATIC on Polygon), the Uniswap protocol wraps these assets in an ERC20 wrapped native token contract. The protocol uses the following WETH9 addresses on Ethereum and WMATIC addresses on Polygon.
+The Uniswap Protocol supports trading of ERC20 tokens. In order to swap a native asset like ETH (or MATIC on Polygon), the Uniswap protocol wraps these assets in an ERC20 wrapped native token contract. The protocol uses the following WETH addresses on Worldchain.
 
 | Network             | ChainId  | Wrapped Native Token | Address                                      |
 | ------------------- | -------- | -------------------- | -------------------------------------------- |

--- a/docs/contracts/v3/reference/deployments/ZKsync-Deployments.md
+++ b/docs/contracts/v3/reference/deployments/ZKsync-Deployments.md
@@ -50,9 +50,9 @@ getPool("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "0xc02aaa39b223fe8d0a0e5c4
 
 # Wrapped Native Token Addresses
 
-The Uniswap Protocol supports trading of ERC20 tokens. In order to swap a native asset like ETH (or MATIC on Polygon), the Uniswap protocol wraps these assets in an ERC20 wrapped native token contract. The protocol uses the following WETH9 addresses on Ethereum and WMATIC addresses on Polygon.
+The Uniswap Protocol supports trading of ERC20 tokens. In order to swap a native asset like ETH (or MATIC on Polygon), the Uniswap protocol wraps these assets in an ERC20 wrapped native token contract. The protocol uses the following WETH address on ZKsync.
 
 | Network           | ChainId  | Wrapped Native Token | Address                                      |
 | ----------------- | -------- | -------------------- | -------------------------------------------- |
-| ZKxync            | `324`    | WETH                 | `0x5aea5775959fbc2557cc8789bc1bf90a239d9a91` |
+| ZKsync            | `324`    | WETH                 | `0x5aea5775959fbc2557cc8789bc1bf90a239d9a91` |
 

--- a/docs/contracts/v3/reference/deployments/Zora-Deployments.md
+++ b/docs/contracts/v3/reference/deployments/Zora-Deployments.md
@@ -48,7 +48,7 @@ getPool("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "0xc02aaa39b223fe8d0a0e5c4
 
 # Wrapped Native Token Addresses
 
-The Uniswap Protocol supports trading of ERC20 tokens. In order to swap a native asset like ETH (or MATIC on Polygon), the Uniswap protocol wraps these assets in an ERC20 wrapped native token contract. The protocol uses the following WETH9 addresses on Ethereum and WMATIC addresses on Polygon.
+The Uniswap Protocol supports trading of ERC20 tokens. In order to swap a native asset like ETH (or MATIC on Polygon), the Uniswap protocol wraps these assets in an ERC20 wrapped native token contract. The protocol uses the following WETH addresses on Zora and Zora Sepolia.
 
 | Network      | ChainId     | Wrapped Native Token | Address                                      |
 | ------------ | ----------- | -------------------- | -------------------------------------------- |


### PR DESCRIPTION
**changes**
- editing references to other chains than the current
- correcting relevant symbol for specific chains (WBNB, not WETH, in BSC)