### PR TITLE
fix: typos in documentation files

### DIFF
--- a/docs/contracts/v2/concepts/01-protocol-overview/03-smart-contracts.md
+++ b/docs/contracts/v2/concepts/01-protocol-overview/03-smart-contracts.md
@@ -53,7 +53,7 @@ Typically, smart contracts which need tokens to perform some functionality requi
 
 ## WETH
 
-Unlike Uniswap V1 pools, V2 pairs do not support ETH directly, so ETH⇄ERC-20 pairs must be emulated with WETH. The motivation behind this choice was to remove ETH-specific code in the core, resulting in a leaner codebase. End users can be kept fully ignorant of this implementation detail, however, by simply wrapping/unwrapping ETH in the periphery.
+Unlike Uniswap V1 pools, V2 pairs do not support ETH directly, so ETH⇄ERC-20 pairs must be emulated with WETH. The motivation behind this choice was to remove ETH-specific code in the core, resulting in a cleaner codebase. End users can be kept fully ignorant of this implementation detail, however, by simply wrapping/unwrapping ETH in the periphery.
 
 The router fully supports interacting with any WETH pair via ETH.
 

--- a/docs/contracts/v2/guides/smart-contract-integration/02-trading-from-a-smart-contract.md
+++ b/docs/contracts/v2/guides/smart-contract-integration/02-trading-from-a-smart-contract.md
@@ -56,4 +56,4 @@ Because Ethereum transactions occur in an adversarial environment, smart contrac
 
 The best way to protect against these attacks is to use an external price feed or "price oracle". The best "oracle" is simply _traders' off-chain observation of the current price_, which can be passed into the trade as a safety check. This strategy is best for situations _where users initiate trades on their own behalf_.
 
-However, when an off-chain price can't be used, an on-chain oracle should be used instead. Determining the best oracle for a given situation is a not part of this guide, but for more details on the Uniswap V2 approach to oracles, see [Oracles](../../concepts/core-concepts/oracles).
+However, when an off-chain price can't be used, an on-chain oracle should be used instead. Determining the best oracle for a given situation is not a part of this guide, but for more details on the Uniswap V2 approach to oracles, see [Oracles](../../concepts/core-concepts/oracles).


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `leaner` to `cleaner`
Corrected `situation is a not part` to `situation is not a part`

Please review the changes and let me know if any additional changes are needed.

