### PR TITLE
docs: add v4 updates to Uniswap Protocol Overview and Hooks to Protocol Concepts

### DIFF
--- a/docs/concepts/protocol/concentrated-liquidity.md
+++ b/docs/concepts/protocol/concentrated-liquidity.md
@@ -1,7 +1,7 @@
 ---
 id: concentrated-liquidity
 title: Concentrated Liquidity
-sidebar_position: 1
+sidebar_position: 6
 ---
 
   <div>

--- a/docs/concepts/protocol/fees.md
+++ b/docs/concepts/protocol/fees.md
@@ -1,7 +1,7 @@
 ---
 id: fees
 title: Fees
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 ## Swap Fees

--- a/docs/concepts/protocol/hooks.md
+++ b/docs/concepts/protocol/hooks.md
@@ -1,0 +1,34 @@
+---
+id: hooks
+title: Hooks
+sidebar_position: 1
+---
+
+## Introduction
+
+Uniswap v4 inherits all of the capital efficiency gains of Uniswap v3 while introducing major architectural improvements. 
+
+The key innovations are the Hook System and Singleton Architecture, which together enable unprecedented protocol customization and gas optimization.
+
+## Hooks
+
+Hooks allow developers to customize and extend the behavior of liquidity pools. They are external smart contracts that can be attached to individual pools to intercept and modify the execution flow at specific points during pool-related actions.
+
+The logic is executed before and/or after major operations such as pool creation, liquidity addition and removal, swapping, and donations.
+
+Through these hook functions, developers can build sophisticated features like custom AMMs with different pricing curves, yield farming protocols, advanced trading features including limit orders, dynamic fee strategies, and custom oracle implementations. Each pool can have one hook (though a hook can serve multiple pools), hooks are optional and specified during pool creation, and developers can implement any combination of hook functions based on their needs.
+
+## Singleton Architecture
+
+The hook system in v4 is built on top of a revolutionary architectural change known as the singleton design. Unlike previous versions where each pool was a separate smart contract, v4 manages all pools through a single contract called the [PoolManager](/contracts/v4/concepts/PoolManager). This architectural innovation brings several key improvements:
+
+- **Efficient Pool Creation**: Pools are created as state updates rather than contract deployments, significantly reducing gas costs
+- **Gas Optimization**: Multi-hop swaps and complex operations are streamlined through a single contract
+- **Flash Accounting**: Token balances are tracked internally and settled at the end of transactions, minimizing transfers
+- **Native ETH Support**: Direct ETH trading without the need to wrap to WETH, improving user experience
+
+These core features are just the beginning of what's possible with Uniswap v4. 
+
+To explore all features including flash accounting, native ETH support, dynamic fees, and custom accounting, check out the [v4 whitepaper](https://uniswap.org/whitepaper-v4.pdf). 
+
+For technical implementations and detailed guides, visit the [v4 technical documentation](/contracts/v4/concepts/overview).

--- a/docs/concepts/protocol/integration-issues.md
+++ b/docs/concepts/protocol/integration-issues.md
@@ -1,7 +1,7 @@
 ---
 id: integration-issues
 title: Token Integration Issues
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 Fee-on-transfer and rebasing tokens will not function correctly on v3.

--- a/docs/concepts/protocol/oracle.md
+++ b/docs/concepts/protocol/oracle.md
@@ -1,7 +1,7 @@
 ---
 id: oracle
 title: Oracle
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 :::note

--- a/docs/concepts/protocol/range-orders.md
+++ b/docs/concepts/protocol/range-orders.md
@@ -1,7 +1,7 @@
 ---
 id: range-orders
 title: Range Orders
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 Customizable liquidity positions, along with single-sided asset provisioning, allow for a new style of swapping with automated market makers: the range order.

--- a/docs/concepts/protocol/swaps.md
+++ b/docs/concepts/protocol/swaps.md
@@ -1,7 +1,7 @@
 ---
 id: swaps
 title: Swaps
-sidebar_position: 5
+sidebar_position: 2
 ---
 
 ## Introduction


### PR DESCRIPTION
This PR updates the documentation to include Uniswap v4 features in two main areas:

1. Updates Uniswap Protocol Overview with v4 references
2. Adds Hooks documentation to Protocol Concepts section

Changes

- Update Protocol Overview to include v4 references
- Add new `hooks.md` documentation in Protocol Concepts
- Reorder Protocol Concepts sidebar for better content flow: