### PR TITLE
docs: update homepage guides for v4

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,9 +5,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl'
 import styled from '@emotion/styled'
 import Discord from '@site/static/img/discord.svg'
 import GitHub from '@site/static/img/github.svg'
-import Npm from '@site/static/img/npm.svg'
 import UGP from '@site/static/img/UGP.png'
-
 import Layout from '@theme/Layout'
 import ThemedImage from '@theme/ThemedImage'
 import { TraceEvent } from '@uniswap/analytics'
@@ -97,27 +95,27 @@ export const smartContractGuides = [
   {
     title: 'Setup your environment',
     text: 'Prepare your local environment by installing the required dependencies',
-    to: '/contracts/v3/guides/local-environment',
+    to: '/contracts/v4/quickstart/hooks/setup',
   },
   {
     title: 'Implement a Swap',
     text: 'Start swapping from a smart contract in Solidity',
-    to: '/contracts/v3/guides/swaps/single-swaps',
+    to: 'contracts/v4/quickstart/swap',
   },
   {
     title: 'Provide Liquidity',
     text: 'Provide liquidity from a smart contract in Solidity',
-    to: '/contracts/v3/guides/providing-liquidity/setting-up',
-  },
-  {
-    title: 'Mine Liquidity',
-    text: 'Start Mining liquidity from a smart contract in Solidity',
-    to: '/contracts/v3/guides/liquidity-mining/overview',
+    to: 'contracts/v4/quickstart/manage-liquidity/setup-liquidity',
   },
   {
     title: 'Implement Flash Swaps',
     text: 'Implement Flash Swaps from a smart contract in Solidity',
-    to: '/contracts/v3/guides/flash-integrations/inheritance-constructors',
+    to: '/contracts/v4/guides/flash-accounting',
+  },
+  {
+    title: 'Create a Hook',
+    text: 'Create your first hook to customize pool behavior in Solidity',
+    to: '/contracts/v4/guides/hooks/your-first-hook',
   },
 ]
 
@@ -344,13 +342,15 @@ export default function Home() {
             ))}
           </Row>
         </DocsHeader>
-        <TwoRow
+        <div
           style={{
-            gap: '56px',
-            marginTop: '4rem',
+            width: '100%',
+            maxWidth: '960px',
+            margin: '4rem auto',
+            padding: '0 1rem',
           }}
         >
-          <div>
+          {/* <div>
             <h2>Integrate your dApp</h2>
             <p>Explore these guided tutorials to get started integrating with Uniswap in your dApp.</p>
             <div>
@@ -378,7 +378,7 @@ export default function Home() {
                 </TraceEvent>
               ))}
             </div>
-          </div>
+          </div> */}
           <div>
             <h2>Integrate your smart contracts</h2>
             <p>Explore these guided tutorials to get started integrating with Uniswap in your smart contracts.</p>
@@ -408,7 +408,7 @@ export default function Home() {
               ))}
             </div>
           </div>
-        </TwoRow>
+        </div>
         <hr />
         <TwoRow
           style={{
@@ -465,7 +465,7 @@ export default function Home() {
             <Link style={{ textDecoration: 'none' }} href={'https://discord.gg/ybKVQUWb4s'}>
               <CenterCard>
                 <StyledIcon>
-                   <Discord style={{ width: '48px', height: '48px' }} />
+                  <Discord style={{ width: '48px', height: '48px' }} />
                 </StyledIcon>
                 <div>
                   <h3>Discord</h3>
@@ -530,7 +530,8 @@ export default function Home() {
             <div>
               <h2 style={{ marginBottom: '0.5rem' }}>Uniswap Foundation Grants</h2>
               <p style={{ margin: '0rem' }}>
-              In pursuit of a more open and fair financial system, the Uniswap Foundation supports the growth, decentralization, and sustainability of the Uniswap community.{' '}
+                In pursuit of a more open and fair financial system, the Uniswap Foundation supports the growth,
+                decentralization, and sustainability of the Uniswap community.{' '}
               </p>
             </div>
           </WideCard>


### PR DESCRIPTION
Updates the homepage guides section to reflect v4 documentation structure.

Changes
- Remove dApp integration section temporarily (until we have v4 SDK guides)
- Update smart contract guides with correct v4 paths
- Add "Create a Hook" guide section
- Improve layout of smart contract guides section