### PR TITLE
docs: update READ.ME with v4 references

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,12 @@
 
 This web application contains all documentation for Uniswap products. It is built using [Docusaurus 2](https://v2.docusaurus.io/), a modern static website generator.
 
-
 # Project Layout
 
 ### Uniswap documentation is broken down into four sections:
-- Concepts - General Uniswap information or concepts useful for using Uniswap products, such as *Liquidity* and *Fees*
-- Contracts - Uniswap smart contracts such as the V3 Contracts or *Permit2*
-- SDKs - Uniswap integrations such as the *v3-sdk* and the *Swap Widget*
+- Concepts - General Uniswap information or concepts useful for using Uniswap products, such as *Hooks* and *Fees*
+- Contracts - Uniswap smart contracts including *v4*, *v3*, *UniswapX*, *Universal Router*, *Permit2*, *v2*, and *v1*
+- SDKs - Uniswap integrations such as the *v4-sdk*, *v3-sdk* and the *Swap Widget*
 - APIs - The Uniswap APIs such the *Subgraph API*
 
 ### Each item in a section should include the following:
@@ -27,7 +26,7 @@ A product overview should address points such as:
 - Where does the source code of the product live?
 - Where does the code artifact live (eg *npm*) and how does someone integrate with it?
 
-A good example is the [V3 Smart Contracts](./docs/contracts/v3/overview.md).
+A good example is the [v4 Smart Contracts](./docs/contracts/v4/overview).
 
 ### Guides
 > Guides should follow the **Principles of a Good Guide**:
@@ -48,10 +47,10 @@ A good example is the [V3 Smart Contracts](./docs/contracts/v3/overview.md).
 By implementing these consistent principles Uniswap will have docs that are easy to understand and produce reusable code for its community.
 
 
-A good example is the [V3 SDK Guides](./docs/sdk/v3/guides/01-quick-start.md).
+A good example is the [v3 SDK Guides](./docs/sdk/v3/guides/01-background.md).
 
 ### Technical References
-This should contain the technical reference for the exported interfaces. A good example is the [V3 SDK](./docs/sdk/v3/reference/overview).
+This should contain the technical reference for the exported interfaces. A good example is the [v4 SDK](./docs/sdk/v4/overview).
 These files can be created using the [guides below](#how-to-create-a-technical-reference).
 
 # Contributing to Uniswap Docs
@@ -124,7 +123,7 @@ If you don't have those, one for the Engineering Managers should be able to help
 - Edit config.json file if needed:
     - Start url from updated website
     - Sitemap url from updated website: eg for docs: https://docs.uniswap.org/sitemap.xml
-    - Use "v3-docs" as the index name
+    - Use "v4-docs" as the index name
 - [Install](https://www.docker.com/products/docker-desktop/) and start running Docker Desktop
 - Install jq `brew install jq`
 - Run `docker run -it --env-file=.env -e "CONFIG=$(cat ./config.json | jq -r tostring)" algolia/docsearch-scraper`


### PR DESCRIPTION
Updates the README to reflect v4 documentation structure and references.

Changes
- Updated Project Layout section to include v4 protocol and related contracts
- Updated contract list order (v4, v3, UniswapX, Universal Router, Permit2, v2, v1)
- Updated documentation example links
- Maintained v3 SDK guide as reference for comprehensive guides
