### PR TITLE
Fix layout at narrow width #125

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -160,7 +160,7 @@ const TwoRow = styled(Row)`
 const Card = styled.div`
   display: flex;
   max-height: 250px;
-  min-width: 350px;
+  width: 100%;
   padding: 1rem;
   flex-direction: column;
   justify-content: center;
@@ -259,6 +259,11 @@ const DocsHeader = styled.div`
   overflow: hidden;
   width: 100%;
   position: relative;
+  padding: 0 1rem;
+  
+  @media (max-width: 960px) {
+    padding: 0;
+  }
 `
 
 const StyledImage = styled(ThemedImage)`

--- a/src/theme/SearchBar.tsx
+++ b/src/theme/SearchBar.tsx
@@ -1,17 +1,35 @@
+import styled from '@emotion/styled'
 import OriginalSearchBar from '@theme-original/SearchBar'
 import { TraceEvent } from '@uniswap/analytics'
 import { BrowserEvent, SharedEventName } from '@uniswap/analytics-events'
 import React from 'react'
 
+const SearchWrapper = styled.div`
+  div[class*="searchBox_"] {
+    position: static !important;
+    padding: 0 !important;
+    margin: 0 !important;
+  }
+
+  .DocSearch.DocSearch-Button {
+    position: relative !important;
+    top: auto !important;
+    left: auto !important;
+    right: auto !important;
+    bottom: auto !important;
+    transform: none !important;
+  }
+`
+
 export default function SearchBarWithAnalytics(props) {
   return (
-    <>
-      <TraceEvent events={[BrowserEvent.onClick]} name={SharedEventName.SEARCH_BAR_CLICKED}>
-        {/* Required for onClick to register */}
-        <div>
-          <OriginalSearchBar {...props} />
-        </div>
-      </TraceEvent>
-    </>
+    <TraceEvent 
+      events={[BrowserEvent.onClick]} 
+      name={SharedEventName.SEARCH_BAR_CLICKED}
+    >
+      <SearchWrapper>
+        <OriginalSearchBar {...props} />
+      </SearchWrapper>
+    </TraceEvent>
   )
 }


### PR DESCRIPTION
Fixes #125 
This PR fixes the layout issues that occur at narrow viewport widths before the mobile layout kicks in.

Changes made:
- Added responsive styles for navigation elements to prevent overflow
- Adjusted search button positioning to maintain consistency
