### PR TITLE
docs: add Soneium and Ink v4 deployments

### DIFF
--- a/docs/contracts/v4/deployments.mdx
+++ b/docs/contracts/v4/deployments.mdx
@@ -92,6 +92,26 @@ The latest version of `@uniswap/v4-core`, `@uniswap/v4-periphery`, and `@uniswap
 | [StateView](https://github.com/Uniswap/v4-periphery/blob/main/src/lens/StateView.sol) | [`0x51d394718bc09297262e368c1a481217fdeb71eb`](https://worldscan.org/address/0x51d394718bc09297262e368c1a481217fdeb71eb) |
 | [Universal Router](https://github.com/Uniswap/universal-router/blob/dev/contracts/UniversalRouter.sol) | [`0x8ac7bee993bb44dab564ea4bc9ea67bf9eb5e743`](https://worldscan.org/address/0x8ac7bee993bb44dab564ea4bc9ea67bf9eb5e743) |
 
+### Ink: 57073
+| Contract | Address |
+|----------|---------|
+| [PoolManager](https://github.com/Uniswap/v4-core/blob/main/src/PoolManager.sol) | [`0x360e68faccca8ca495c1b759fd9eee466db9fb32`](https://explorer.inkonchain.com/address/0x360e68faccca8ca495c1b759fd9eee466db9fb32) |
+| [PositionDescriptor](https://github.com/Uniswap/v4-periphery/blob/main/src/PositionDescriptor.sol) | [`0x42e3ccd9b7f67b5b2ee0c12074b84ccf2a8e7f36`](https://explorer.inkonchain.com/address/0x42e3ccd9b7f67b5b2ee0c12074b84ccf2a8e7f36) |
+| [PositionManager](https://github.com/Uniswap/v4-periphery/blob/main/src/PositionManager.sol) | [`0x1b35d13a2e2528f192637f14b05f0dc0e7deb566`](https://explorer.inkonchain.com/address/0x1b35d13a2e2528f192637f14b05f0dc0e7deb566) |
+| [Quoter](https://github.com/Uniswap/v4-periphery/blob/main/src/lens/V4Quoter.sol) | [`0x3972c00f7ed4885e145823eb7c655375d275a1c5`](https://explorer.inkonchain.com/address/0x3972c00f7ed4885e145823eb7c655375d275a1c5) |
+| [StateView](https://github.com/Uniswap/v4-periphery/blob/main/src/lens/StateView.sol) | [`0x76fd297e2d437cd7f76d50f01afe6160f86e9990`](https://explorer.inkonchain.com/address/0x76fd297e2d437cd7f76d50f01afe6160f86e9990) |
+| [Universal Router](https://github.com/Uniswap/universal-router/blob/dev/contracts/UniversalRouter.sol) | [`0x112908dac86e20e7241b0927479ea3bf935d1fa0`](https://explorer.inkonchain.com/address/0x112908dac86e20e7241b0927479ea3bf935d1fa0) |
+
+### Soneium: 1868
+| Contract | Address |
+|----------|---------|
+| [PoolManager](https://github.com/Uniswap/v4-core/blob/main/src/PoolManager.sol) | [`0x360e68faccca8ca495c1b759fd9eee466db9fb32`](https://soneium.blockscout.com/address/0x360e68faccca8ca495c1b759fd9eee466db9fb32) |
+| [PositionDescriptor](https://github.com/Uniswap/v4-periphery/blob/main/src/PositionDescriptor.sol) | [`0x42e3ccd9b7f67b5b2ee0c12074b84ccf2a8e7f36`](https://soneium.blockscout.com/address/0x42e3ccd9b7f67b5b2ee0c12074b84ccf2a8e7f36) |
+| [PositionManager](https://github.com/Uniswap/v4-periphery/blob/main/src/PositionManager.sol) | [`0x1b35d13a2e2528f192637f14b05f0dc0e7deb566`](https://soneium.blockscout.com/address/0x1b35d13a2e2528f192637f14b05f0dc0e7deb566) |
+| [Quoter](https://github.com/Uniswap/v4-periphery/blob/main/src/lens/V4Quoter.sol) | [`0x3972c00f7ed4885e145823eb7c655375d275a1c5`](https://soneium.blockscout.com/address/0x3972c00f7ed4885e145823eb7c655375d275a1c5) |
+| [StateView](https://github.com/Uniswap/v4-periphery/blob/main/src/lens/StateView.sol) | [`0x76fd297e2d437cd7f76d50f01afe6160f86e9990`](https://soneium.blockscout.com/address/0x76fd297e2d437cd7f76d50f01afe6160f86e9990) |
+| [Universal Router](https://github.com/Uniswap/universal-router/blob/dev/contracts/UniversalRouter.sol) | [`0x4cded7edf52c8aa5259a54ec6a3ce7c6d2a455df`](https://soneium.blockscout.com/address/0x4cded7edf52c8aa5259a54ec6a3ce7c6d2a455df) |
+
 ### Avalanche: 43114
 | Contract | Address |
 |----------|---------|


### PR DESCRIPTION
Adds deployment information for v4 contracts on Soneium Network and Ink Chain.

Changes

- Add Soneium Network contract addresses with blockscout explorer links
- Add Ink Chain contract addresses with explorer links
- Include all core v4 contracts:
  - PoolManager
  - PositionDescriptor
  - PositionManager
  - Quoter
  - StateView
  - Universal Router