### PR TITLE
docs: fix NoOp term to AsyncSwap

### DIFF
--- a/docs/contracts/v4/quickstart/04-hooks/03-async-swap.mdx
+++ b/docs/contracts/v4/quickstart/04-hooks/03-async-swap.mdx
@@ -4,7 +4,7 @@ title: AsyncSwap Hooks
 
 One feature enabled by [custom accounting](/contracts/v4/guides/custom-accounting) is​​​​‌ AsyncSwap swap. This feature allows hook developers to replace the v4 (v3-style) swap logic.
 
-This means developers can replace Uniswap's internal core logic for how to handle swaps. Two emergent use-cases are possible with AsyncSwap:
+This means developers can replace Uniswap's internal core logic for how to handle swaps. Two emergent use-cases are possible with custom accounting:
 
 1. Asynchronous swaps and swap-ordering. Delay the v4 swap logic for fulfillment at a later time.
 2. Custom Curves. Replace the v4 swap logic with different swap logic. The custom logic is flexible and developers can implement symmetric curves, asymmetric curves, or custom quoting.

--- a/docs/contracts/v4/quickstart/04-hooks/03-async-swap.mdx
+++ b/docs/contracts/v4/quickstart/04-hooks/03-async-swap.mdx
@@ -1,27 +1,27 @@
 ---
-title: NoOp Hooks
+title: AsyncSwap Hooks
 ---
 
-One feature enabled by [custom accounting](/contracts/v4/guides/custom-accounting) is​​​​‌ NoOp swap. This feature allows hook developers to replace the v4 (v3-style) swap logic.
+One feature enabled by [custom accounting](/contracts/v4/guides/custom-accounting) is​​​​‌ AsyncSwap swap. This feature allows hook developers to replace the v4 (v3-style) swap logic.
 
-This means developers can replace Uniswap's internal core logic for how to handle swaps. Two emergent use-cases are possible with NoOp:
+This means developers can replace Uniswap's internal core logic for how to handle swaps. Two emergent use-cases are possible with AsyncSwap:
 
 1. Asynchronous swaps and swap-ordering. Delay the v4 swap logic for fulfillment at a later time.
 2. Custom Curves. Replace the v4 swap logic with different swap logic. The custom logic is flexible and developers can implement symmetric curves, asymmetric curves, or custom quoting.
 
-> NoOp is typically described as taking the full input to replace the internal swap logic, partially taking the input is better described as *custom accounting*
+> AsyncSwap is typically described as taking the full input to replace the internal swap logic, partially taking the input is better described as *custom accounting*
 
-Note: The flexibility of NoOp means hook developers can implement harmful behavior (such as taking all swap amounts for themselves, charging extra fees, etc.). Hooks with NoOp behavior should be examined very closely by both developers and users.
+Note: The flexibility of AsyncSwap means hook developers can implement harmful behavior (such as taking all swap amounts for themselves, charging extra fees, etc.). Hooks with AsyncSwap behavior should be examined very closely by both developers and users.
 
-# Configure a NoOp Hook
+# Configure a AsyncSwap Hook
 
-To enable NoOp, developers will need the hook permission `BEFORE_SWAP_RETURNS_DELTA_FLAG`
+To enable AsyncSwap, developers will need the hook permission `BEFORE_SWAP_RETURNS_DELTA_FLAG`
 
 ```solidity
 import {BaseHook} from "v4-periphery/BaseHook.sol";
 // ...
 
-contract NoOpHook is BaseHook {
+contract AsyncSwapHook is BaseHook {
     // ...
 
     function getHookPermissions() public pure virtual override returns (Hooks.Permissions memory) {
@@ -49,7 +49,7 @@ contract NoOpHook is BaseHook {
 
 # beforeSwap
 
-NoOp only works on exact-input swaps and the *beforeSwap* **must** take the input currency and return [`BeforeSwapDelta`](/contracts/v4/reference/core/types/beforeswapdelta). The hook should `IPoolManager.mint` itself the corresponding tokens equal to the amount of the input (`amountSpecified`). It should then return a `BeforeSwapDelta` where `deltaSpecified = -amountSpecified` (the positive amount).
+AsyncSwap only works on exact-input swaps and the *beforeSwap* **must** take the input currency and return [`BeforeSwapDelta`](/contracts/v4/reference/core/types/beforeswapdelta). The hook should `IPoolManager.mint` itself the corresponding tokens equal to the amount of the input (`amountSpecified`). It should then return a `BeforeSwapDelta` where `deltaSpecified = -amountSpecified` (the positive amount).
 
 The funds' movements are as follows:
 
@@ -61,7 +61,7 @@ The funds' movements are as follows:
 6. The swap router pays off the debt using the user's tokens
 
 ```solidity
-contract NoOpHook is BaseHook {
+contract AsyncSwapHook is BaseHook {
      // ...
 
     function beforeSwap(address, PoolKey calldata key, IPoolManager.SwapParams calldata params, bytes calldata)
@@ -69,14 +69,14 @@ contract NoOpHook is BaseHook {
         override
         returns (bytes4, BeforeSwapDelta, uint24)
     {
-        // NoOp only works on exact-input swaps
+        // AsyncSwap only works on exact-input swaps
         if (params.amountSpecified < 0) {
             // take the input token so that v3-swap is skipped...
             Currency input = params.zeroForOne ? key.currency0 : key.currency1;
             uint256 amountTaken = uint256(-params.amountSpecified);
             poolManager.mint(address(this), input.toId(), amountTaken);
 
-            // to NoOp the exact input, we return the amount that's taken by the hook
+            // to AsyncSwap the exact input, we return the amount that's taken by the hook
             return (BaseHook.beforeSwap.selector, toBeforeSwapDelta(amountTaken.toInt128(), 0), 0);
         }
         else {
@@ -89,7 +89,7 @@ contract NoOpHook is BaseHook {
 
 # Testing
 
-To verify the NoOp behaved properly, developers should test the swap and that token balances match expected behavior.
+To verify the AsyncSwap behaved properly, developers should test the swap and that token balances match expected behavior.
 
 ```solidity
 // SPDX-License-Identifier: MIT
@@ -99,14 +99,14 @@ import "forge-std/Test.sol";
 import {Deployers} from "v4-core/test/utils/Deployers.sol";
 // ...
 
-contract NoOpSwapTest is Test, Deployers {
+contract AsyncSwapTest is Test, Deployers {
     // ...
 
     function setUp() public {
         // ... 
     }
 
-    function test_noOp() public {
+    function test_asyncSwap() public {
         assertEq(hook.beforeSwapCount(poolId), 0);
 
         uint256 balance0Before = currency0.balanceOfSelf();
@@ -124,7 +124,7 @@ contract NoOpSwapTest is Test, Deployers {
         // user paid token0
         assertEq(balance0Before - balance0After, 1e18);
 
-        // user did not recieve token1 (NoOp)
+        // user did not recieve token1 (AsyncSwap)
         assertEq(balance1Before, balance1After);
     }
 }


### PR DESCRIPTION
Updates terminology from NoOp to AsyncSwap for clarity and consistency.

Changes
- Rename file from 03-NoOp.mdx to 03-async-swap.mdx
- Update all instances of NoOp to AsyncSwap in the document
- Maintain consistent terminology throughout the documentation
