### PR TITLE
docs: fix uf grants copy and deployments route

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -129,7 +129,7 @@ module.exports = {
             },
             {
               label: 'Deployment addresses',
-              href: 'https://docs.uniswap.org/contracts/v4/deployments',
+              href: '/contracts/v4/deployments',
             },
           ],
         },

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -528,7 +528,7 @@ export default function Home() {
           >
             <img src={UGP} width={'120px'} />
             <div>
-              <h2 style={{ marginBottom: '0.5rem' }}>Uniswap Foundation Grants</h2>
+              <h2 style={{ marginBottom: '0.5rem' }}>Uniswap Foundation</h2>
               <p style={{ margin: '0rem' }}>
                 In pursuit of a more open and fair financial system, the Uniswap Foundation supports the growth,
                 decentralization, and sustainability of the Uniswap community.{' '}


### PR DESCRIPTION
Updates copy related to Uniswap Foundation and fixes deployments route.

Changes
- Remove "grants" reference from Uniswap Foundation description
- Fix deployments route in the footer /contracts/v4/deployments