### PR TITLE
docs: add BaseDynamicAfterFee to OZ hooks list

### DIFF
--- a/docs/contracts/v4/quickstart/04-hooks/00-setup.mdx
+++ b/docs/contracts/v4/quickstart/04-hooks/00-setup.mdx
@@ -240,3 +240,4 @@ The library includes:
 - **BaseAsyncSwap**: For implementing non-atomic and asynchronous swaps
 - **BaseDynamicFee**: For implementing dynamic fee pools
 - **BaseOverrideFee**: For implementing dynamic fees on every swap
+- **BaseDynamicAfterFee**: For implementing post-swap fee adjustments based on actual swap output


### PR DESCRIPTION
Adds BaseDynamicAfterFee to the OpenZeppelin Hooks Library section.