### PR TITLE
docs: update protocol concepts v4

### DIFF
--- a/docs/concepts/protocol/concentrated-liquidity.md
+++ b/docs/concepts/protocol/concentrated-liquidity.md
@@ -1,7 +1,7 @@
 ---
 id: concentrated-liquidity
 title: Concentrated Liquidity
-sidebar_position: 1
+sidebar_position: 6
 ---
 
   <div>

--- a/docs/concepts/protocol/concentrated-liquidity.md
+++ b/docs/concepts/protocol/concentrated-liquidity.md
@@ -13,6 +13,10 @@ sidebar_position: 6
 
 ---
 
+:::note
+Concentrated liquidity, first introduced as a native feature in Uniswap v3, maintains the same core implementation in v4, ensuring consistency in how liquidity providers can focus their capital.
+:::
+
 ## Introduction
 
 The defining idea of Uniswap v3 is concentrated liquidity: liquidity that is allocated within a custom price range.

--- a/docs/concepts/protocol/fees.md
+++ b/docs/concepts/protocol/fees.md
@@ -32,6 +32,6 @@ Similarly, we anticipate more exotic assets, or those traded rarely, will natura
 
 ## Protocol Fees
 
-Both Uniswap v3 and v4 include a protocol fee mechanism that can be activated through UNI governance. This fee structure offers greater flexibility compared to v2, allowing governance to adjust the fraction of swap fees allocated to the protocol. In v4, this mechanism has been further enhanced with additional features like dynamic fee adjustment. For detailed information about protocol fees, refer to the [v3 whitepaper](https://uniswap.org/whitepaper-v3.pdf) and [v4 whitepaper](https://uniswap.org/whitepaper-v4.pdf).
+Both Uniswap v3 and v4 include a protocol fee mechanism that can be activated through UNI governance. This fee structure offers greater flexibility compared to v2, allowing governance to adjust the fraction of swap fees allocated to the protocol. For detailed information about protocol fees, refer to the [v3 whitepaper](https://uniswap.org/whitepaper-v3.pdf) and [v4 whitepaper](https://uniswap.org/whitepaper-v4.pdf).
 
 [^1]: In-range liquidity refers to the liquidity contained in any positions which span both sides of the spot price.

--- a/docs/concepts/protocol/fees.md
+++ b/docs/concepts/protocol/fees.md
@@ -1,7 +1,7 @@
 ---
 id: fees
 title: Fees
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 ## Swap Fees

--- a/docs/concepts/protocol/fees.md
+++ b/docs/concepts/protocol/fees.md
@@ -4,6 +4,10 @@ title: Fees
 sidebar_position: 3
 ---
 
+:::note
+While v3 uses predefined fee tiers (0.01%, 0.05%, 0.3%, and 1%), v4 introduces flexible fees that can range from 0% to 100%, offering greater customization options for pools.
+:::
+
 ## Swap Fees
 
 Swap fees are distributed pro-rata to all in-range[^1] liquidity at the time of the swap. If the spot price moves out of a position’s range, the given liquidity is no longer active and does not generate any fees. If the spot price reverses and reenters the position’s range, the position’s liquidity becomes active again and will generate fees.
@@ -12,7 +16,7 @@ Swap fees are not automatically reinvested as they were in previous versions of 
 
 ## Pool Fees Tiers
 
-Uniswap v3 introduces multiple pools for each token pair, each with a different swapping fee. Liquidity providers may initially create pools at three fee levels: 0.05%, 0.30%, and 1%. More fee levels may be added by UNI governance, e.g. the 0.01% fee level added by [this](https://app.uniswap.org/#/vote/2/9) governance proposal in November 2021, as executed [here](https://etherscan.io/tx/0x5c84f89a67237db7500538b81af61ebd827c081302dd73a1c20c8f6efaaf4f3c).
+Uniswap v3 introduces multiple pools for each token pair, each with a different swapping fee. Liquidity providers may initially create pools at three fee levels: 0.05%, 0.30%, and 1%. More fee levels may be added by UNI governance, e.g. the 0.01% fee level added by [this](https://vote.uniswapfoundation.org/proposals/9) governance proposal in December 2021, as executed [here](https://etherscan.io/tx/0x5c84f89a67237db7500538b81af61ebd827c081302dd73a1c20c8f6efaaf4f3c).
 
 Breaking pairs into separate pools was previously untenable due to the issue of liquidity fragmentation. Any incentive alignments achieved by more fee optionality invariably resulted in a net loss to traders, due to lower pairwise liquidity and the resulting increase in price impact upon swapping.
 
@@ -28,6 +32,6 @@ Similarly, we anticipate more exotic assets, or those traded rarely, will natura
 
 ## Protocol Fees
 
-Uniswap v3 has a protocol fee that can be turned on by UNI governance. Compared to v2, UNI governance has more flexibility in choosing the fraction of swap fees that go to the protocol. For details regarding the protocol fee, see the [whitepaper](https://uniswap.org/whitepaper-v3.pdf).
+Both Uniswap v3 and v4 include a protocol fee mechanism that can be activated through UNI governance. This fee structure offers greater flexibility compared to v2, allowing governance to adjust the fraction of swap fees allocated to the protocol. In v4, this mechanism has been further enhanced with additional features like dynamic fee adjustment. For detailed information about protocol fees, refer to the [v3 whitepaper](https://uniswap.org/whitepaper-v3.pdf) and [v4 whitepaper](https://uniswap.org/whitepaper-v4.pdf).
 
 [^1]: In-range liquidity refers to the liquidity contained in any positions which span both sides of the spot price.

--- a/docs/concepts/protocol/hooks.md
+++ b/docs/concepts/protocol/hooks.md
@@ -1,0 +1,34 @@
+---
+id: hooks
+title: Hooks
+sidebar_position: 1
+---
+
+## Introduction
+
+Uniswap v4 inherits all of the capital efficiency gains of Uniswap v3 while introducing major architectural improvements. 
+
+The key innovations are the Hook System and Singleton Architecture, which together enable unprecedented protocol customization and gas optimization.
+
+## Hooks
+
+Hooks allow developers to customize and extend the behavior of liquidity pools. They are external smart contracts that can be attached to individual pools to intercept and modify the execution flow at specific points during pool-related actions.
+
+The logic is executed before and/or after major operations such as pool creation, liquidity addition and removal, swapping, and donations.
+
+Through these hook functions, developers can build sophisticated features like custom AMMs with different pricing curves, yield farming protocols, advanced trading features including limit orders, dynamic fee strategies, and custom oracle implementations. Each pool can have one hook (though a hook can serve multiple pools), hooks are optional and specified during pool creation, and developers can implement any combination of hook functions based on their needs.
+
+## Singleton Architecture
+
+The hook system in v4 is built on top of a revolutionary architectural change known as the singleton design. Unlike previous versions where each pool was a separate smart contract, v4 manages all pools through a single contract called the [PoolManager](/contracts/v4/concepts/PoolManager). This architectural innovation brings several key improvements:
+
+- **Efficient Pool Creation**: Pools are created as state updates rather than contract deployments, significantly reducing gas costs
+- **Gas Optimization**: Multi-hop swaps and complex operations are streamlined through a single contract
+- **Flash Accounting**: Token balances are tracked internally and settled at the end of transactions, minimizing transfers
+- **Native ETH Support**: Direct ETH trading without the need to wrap to WETH, improving user experience
+
+These core features are just the beginning of what's possible with Uniswap v4. 
+
+To explore all features including flash accounting, native ETH support, dynamic fees, and custom accounting, check out the [v4 whitepaper](https://uniswap.org/whitepaper-v4.pdf). 
+
+For technical implementations and detailed guides, visit the [v4 technical documentation](/contracts/v4/concepts/overview).

--- a/docs/concepts/protocol/integration-issues.md
+++ b/docs/concepts/protocol/integration-issues.md
@@ -1,7 +1,7 @@
 ---
 id: integration-issues
 title: Token Integration Issues
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 Fee-on-transfer and rebasing tokens will not function correctly on v3.

--- a/docs/concepts/protocol/oracle.md
+++ b/docs/concepts/protocol/oracle.md
@@ -1,7 +1,7 @@
 ---
 id: oracle
 title: Oracle
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 :::note

--- a/docs/concepts/protocol/oracle.md
+++ b/docs/concepts/protocol/oracle.md
@@ -5,7 +5,7 @@ sidebar_position: 4
 ---
 
 :::note
-Unfamiliar with the concept of an oracle? Check out the Ethereum Foundation's [oracle overview](https://ethereum.org/en/developers/docs/oracles/) first.
+Uniswap v4 does not include built-in oracle functionality. If you're unfamiliar with oracles, check out the Ethereum Foundation's [oracle overview](https://ethereum.org/en/developers/docs/oracles/).
 :::
 
 All Uniswap v3 pools can serve as oracles, offering access to historical price and liquidity data. This capability unlocks a wide range of on-chain use cases.

--- a/docs/concepts/protocol/range-orders.md
+++ b/docs/concepts/protocol/range-orders.md
@@ -1,7 +1,7 @@
 ---
 id: range-orders
 title: Range Orders
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 Customizable liquidity positions, along with single-sided asset provisioning, allow for a new style of swapping with automated market makers: the range order.

--- a/docs/concepts/protocol/range-orders.md
+++ b/docs/concepts/protocol/range-orders.md
@@ -4,6 +4,10 @@ title: Range Orders
 sidebar_position: 5
 ---
 
+:::note
+Range orders have the same implementation in both Uniswap v3 and v4, offering consistent functionality across both versions.
+:::
+
 Customizable liquidity positions, along with single-sided asset provisioning, allow for a new style of swapping with automated market makers: the range order.
 
 In typical order book markets, anyone can easily set a limit order: to buy or sell an asset at a specific predetermined price, allowing the order to be filled at an indeterminate time in the future.

--- a/docs/concepts/protocol/swaps.md
+++ b/docs/concepts/protocol/swaps.md
@@ -1,7 +1,7 @@
 ---
 id: swaps
 title: Swaps
-sidebar_position: 5
+sidebar_position: 2
 ---
 
 ## Introduction

--- a/docs/contracts/v4/overview.mdx
+++ b/docs/contracts/v4/overview.mdx
@@ -10,9 +10,6 @@ Uniswap v4 inherits all of the capital efficiency gains of Uniswap v3, but provi
 
 For additional information, see the [Uniswap v4 whitepaper](https://github.com/Uniswap/v4-core/blob/main/docs/whitepaper/whitepaper-v4.pdf)
 
----
-
-
 ## Hooks
 
 Developers can attach solidity logic to the _swap lifecycle_ through Hooks. The logic is executed before and/or after major operations such as

--- a/docs/contracts/v4/quickstart/05-subscriber.mdx
+++ b/docs/contracts/v4/quickstart/05-subscriber.mdx
@@ -6,8 +6,6 @@ title: Subscriber
 
 For developers looking to support custom _liquidity mining_, Subscriber contracts can be used to receive notifications about position modifications or transfers.
 
----
-
 # Guide
 
 ## 1. Implement the [`ISubscriber`](https://github.com/Uniswap/v4-periphery/blob/main/src/interfaces/ISubscriber.sol) interface


### PR DESCRIPTION
Updates protocol concepts documentation to clarify feature implementations across v3 and v4.

Changes
- **Oracle**: Clarify that v4 does not include built-in oracle functionality
- **Fees**: 
  - Add note about v4's flexible fee range (0-100%)
  - Update protocol fee section to include v4 enhancements
  - Maintain v3 fee tier references
- **Concentrated Liquidity**: 
  - Clarify it remains the same in v4 as implemented in v3
  - Maintain existing documentation as it applies to both versions
- **Range Orders**: 
  - Add note about identical implementation in v3 and v4
  - Keep existing documentation as it applies to both versions
