### PR TITLE
Grammar and Numbering Fixes

### DIFF
--- a/docs/contracts/uniswapx/02-v1-vs-v2.md
+++ b/docs/contracts/uniswapx/02-v1-vs-v2.md
@@ -20,7 +20,7 @@ In V1, the RFQ flow operates entirely pre-signature. Users request a swap quote,
 
 V2 rearchitects the flow such that the time between a quoter submitting their quote and being required to fill the order is minimized. This enforces a near 100% fill rate and causes most orders to fill almost instantly.
 
-Two achieve this, the quoting flow is divided into two phases:
+To achieve this, the quoting flow is divided into two phases:
 
 1. **Indicative Quotes**: Provided pre-signature when the swapper is exploring quotes but has not committed to trading. Quoters can participate here without being held fully accountable.  
 2. **Hard Quotes**: Provided post-signature when the swapper has committed to trading. Quoters are held fully accountable for these quotes.
@@ -38,7 +38,7 @@ To prevent gaming, quoters cannot distinguish between indicative and hard quotes
 2. The Uniswap Backend (URA) runs an indicative RFQ auction, soliciting quotes for the best price. (**Note:** Quoters do not know whether the RFQ is indicative or hard, forcing them to always provide competitive prices.)
 3. The quotes from the RFQ process parameterize an [initial quote](https://github.com/Uniswap/UniswapX/blob/33fa564cfaa6d58f6e3fcf7e7988cb5fc1c61de7/src/lib/V2DutchOrderLib.sol#L31) order shown to the user.  
 4. The user signs the order and submits it for execution.  
-6. The Uniswap Backend (GPA) runs a second “hard” RFQ process, soliciting new quotes.  
+5. The Uniswap Backend (GPA) runs a second “hard” RFQ process, soliciting new quotes.  
 6. Quoters return their best prices again.  
    * If the price is within or improves on the user’s signed parameters, it is finalized and added to the order’s [CosignerData](https://github.com/Uniswap/UniswapX/blob/33fa564cfaa6d58f6e3fcf7e7988cb5fc1c61de7/src/lib/V2DutchOrderLib.sol#L20).  
    * If the price moves outside the signed parameters, the order fails, and the user must try again.  

--- a/docs/sdk/swap-widget/overview.md
+++ b/docs/sdk/swap-widget/overview.md
@@ -12,7 +12,7 @@ Welcome to the Uniswap Swap Widget. To begin, we recommend looking at the [**Gui
 
 The latest version of the Swap Widget is in production in the Uniswap Interface,
 but it is considered Alpha software and may contain bugs or change significantly between patch versions.
-If you have questions about how to use the SDK, please reach out in the `#dev-chat` channel of our Discord.
+If you have questions about how to use the SDK, please reach out in the `#dev-chat` channel on our Discord.
 Pull requests are welcome!
 
 # Uniswap Swap Widget


### PR DESCRIPTION
Typo Fix:

"Two achieve this" → "To achieve this"
File: docs/contracts/uniswapx/02-v1-vs-v2.md
Numbering Fix:

Fixed incorrect sequence (6 → 5).
File: docs/contracts/uniswapx/02-v1-vs-v2.md
Preposition Fix:

"channel of our Discord" → "channel on our Discord"
File: docs/sdk/swap-widget/overview.md