### PR TITLE
fix: update links to point to correct section

### DIFF
--- a/docs/sdk/core/reference/overview.md
+++ b/docs/sdk/core/reference/overview.md
@@ -25,20 +25,20 @@ title: Overview
 
 ### Type Aliases
 
-- [BigintIsh](modules.md#bigintish)
-- [Currency](modules.md#currency)
+- [BigintIsh](#bigintish)
+- [Currency](#currency)
 
 ### Variables
 
-- [MaxUint256](modules.md#maxuint256)
-- [WETH9](modules.md#weth9)
+- [MaxUint256](#maxuint256)
+- [WETH9](#weth9)
 
 ### Functions
 
-- [computePriceImpact](modules.md#computepriceimpact)
-- [sortedInsert](modules.md#sortedinsert)
-- [sqrt](modules.md#sqrt)
-- [validateAndParseAddress](modules.md#validateandparseaddress)
+- [computePriceImpact](#computepriceimpact)
+- [sortedInsert](#sortedinsert)
+- [sqrt](#sqrt)
+- [validateAndParseAddress](#validateandparseaddress)
 
 ## Type Aliases
 


### PR DESCRIPTION
several links lead to a "Page Not Found" error:
![CleanShot 2025-03-06 at 01 58 19@2x](https://github.com/user-attachments/assets/699b9d6f-d0e1-4679-9efc-aff198dfa299)

this PR should fix them