### PR TITLE
docs: reupload hooks formatting updates

### DIFF
--- a/docs/contracts/v4/guides/08-custom-accounting.mdx
+++ b/docs/contracts/v4/guides/08-custom-accounting.mdx
@@ -135,12 +135,12 @@ Here, we're setting up our hook with a constant fee of 0.01% and enabling the `b
 Now, let's implement our `beforeSwap` function:
 
 ```solidity
-function beforeSwap(
+function _beforeSwap(
     address,
     PoolKey calldata key,
     IPoolManager.SwapParams calldata params,
     bytes calldata
-) external override returns (bytes4, BeforeSwapDelta, uint24) {
+) internal override returns (bytes4, BeforeSwapDelta, uint24) {
     // Implementation details will be explained in the following sub-steps
 }
 

--- a/docs/contracts/v4/guides/10-ERC-6909.mdx
+++ b/docs/contracts/v4/guides/10-ERC-6909.mdx
@@ -83,8 +83,8 @@ This pattern is used throughout v4's operations:
 When building hooks, ERC-6909 operations help manage token movements within your hook's logic:
 
 ```solidity
-function beforeSwap(address, PoolKey calldata key, IPoolManager.SwapParams calldata params)
-    external
+function _beforeSwap(address, PoolKey calldata key, IPoolManager.SwapParams calldata params)
+    internal
     returns (bytes4, BeforeSwapDelta, uint24)
 {
     poolManager.mint(key.currency0, address(this), amount);

--- a/docs/contracts/v4/guides/hooks/05-hook-deployment.mdx
+++ b/docs/contracts/v4/guides/hooks/05-hook-deployment.mdx
@@ -43,7 +43,7 @@ Because of encoded addresses, hook developers must _mine_ an address to a their 
 For local testing, `deployCodeTo` cheatcode in Foundry can be used to deploy hook contract to any address. 
 
 But when deploying hooks to an actual network, address mining is required to find the proper deployment address
-There is a helper library [`HookMiner.sol`](https://github.com/uniswapfoundation/v4-template/blob/main/test/utils/HookMiner.sol) that can be used to mine for correct addresses.
+There is a helper library [`HookMiner.sol`](https://github.com/Uniswap/v4-periphery/blob/main/src/utils/HookMiner.sol) that can be used to mine for correct addresses.
 
 Let's see it in action for a Foundry script. We will make use of the example - Points Hook from [Building Your First Hook](./01-your-first-hook.md).
 
@@ -56,10 +56,10 @@ pragma solidity ^0.8.19;
 import "forge-std/Script.sol";
 import {Hooks} from "v4-core/src/libraries/Hooks.sol";
 import {IPoolManager} from "v4-core/src/interfaces/IPoolManager.sol";
+import {HookMiner} from "v4-periphery/src/utils/HookMiner.sol";
 
 import {Constants} from "./base/Constants.sol";
 import {PointsHook} from "../src/PointsHook.sol";
-import {HookMiner} from "../test/utils/HookMiner.sol";
 
 /// @notice Mines the address and deploys the PointsHook.sol Hook contract
 contract PointsHookScript is Script, Constants {
@@ -101,10 +101,10 @@ pragma solidity ^0.8.19;
 import "forge-std/Script.sol";
 import {Hooks} from "v4-core/src/libraries/Hooks.sol";
 import {IPoolManager} from "v4-core/src/interfaces/IPoolManager.sol";
+import {HookMiner} from "v4-periphery/src/utils/HookMiner.sol";
 
 import {Constants} from "./base/Constants.sol";
 import {PointsHook} from "../src/PointsHook.sol";
-import {HookMiner} from "../test/utils/HookMiner.sol";
 
 /// @notice Mines the address and deploys the PointsHook.sol Hook contract
 contract PointsHookScript is Script, Constants {

--- a/docs/contracts/v4/quickstart/04-hooks/00-setup.mdx
+++ b/docs/contracts/v4/quickstart/04-hooks/00-setup.mdx
@@ -143,8 +143,8 @@ contract CounterHook is BaseHook {
     // NOTE: see IHooks.sol for function documentation
     // -----------------------------------------------
 
-    function beforeSwap(address, PoolKey calldata key, IPoolManager.SwapParams calldata, bytes calldata)
-        external
+    function _beforeSwap(address, PoolKey calldata key, IPoolManager.SwapParams calldata, bytes calldata)
+        internal
         override
         returns (bytes4, BeforeSwapDelta, uint24)
     {
@@ -152,8 +152,8 @@ contract CounterHook is BaseHook {
         return (BaseHook.beforeSwap.selector, BeforeSwapDeltaLibrary.ZERO_DELTA, 0);
     }
 
-    function afterSwap(address, PoolKey calldata key, IPoolManager.SwapParams calldata, BalanceDelta, bytes calldata)
-        external
+    function _afterSwap(address, PoolKey calldata key, IPoolManager.SwapParams calldata, BalanceDelta, bytes calldata)
+        internal
         override
         returns (bytes4, int128)
     {
@@ -161,22 +161,22 @@ contract CounterHook is BaseHook {
         return (BaseHook.afterSwap.selector, 0);
     }
 
-    function beforeAddLiquidity(
+    function _beforeAddLiquidity(
         address,
         PoolKey calldata key,
         IPoolManager.ModifyLiquidityParams calldata,
         bytes calldata
-    ) external override returns (bytes4) {
+    ) internal override returns (bytes4) {
         beforeAddLiquidityCount[key.toId()]++;
         return BaseHook.beforeAddLiquidity.selector;
     }
 
-    function beforeRemoveLiquidity(
+    function _beforeRemoveLiquidity(
         address,
         PoolKey calldata key,
         IPoolManager.ModifyLiquidityParams calldata,
         bytes calldata
-    ) external override returns (bytes4) {
+    ) internal override returns (bytes4) {
         beforeRemoveLiquidityCount[key.toId()]++;
         return BaseHook.beforeRemoveLiquidity.selector;
     }

--- a/docs/contracts/v4/quickstart/04-hooks/01-swap.mdx
+++ b/docs/contracts/v4/quickstart/04-hooks/01-swap.mdx
@@ -81,8 +81,8 @@ function getHookPermissions() public pure override returns (Hooks.Permissions me
 Here the example shows that every time __before__ a swap is executed in a pool, `beforeSwapCount` for that pool will be incremented by one.
 
 ```solidity
-function beforeSwap(address, PoolKey calldata key, IPoolManager.SwapParams calldata, bytes calldata)
-    external
+function _beforeSwap(address, PoolKey calldata key, IPoolManager.SwapParams calldata, bytes calldata)
+    internal
     override
     returns (bytes4, BeforeSwapDelta, uint24)
 {
@@ -106,8 +106,8 @@ A brief overview of the parameters:
 Similiar as above, every time __after__ a swap is executed in a pool, `afterSwapCount` for that pool will be incremented by one.
 
 ```solidity
-function afterSwap(address, PoolKey calldata key, IPoolManager.SwapParams calldata, BalanceDelta, bytes calldata)
-    external
+function _afterSwap(address, PoolKey calldata key, IPoolManager.SwapParams calldata, BalanceDelta, bytes calldata)
+    internal
     override
     returns (bytes4, int128)
 {
@@ -180,8 +180,8 @@ contract SwapHook is BaseHook {
     // NOTE: see IHooks.sol for function documentation
     // -----------------------------------------------
 
-    function beforeSwap(address, PoolKey calldata key, IPoolManager.SwapParams calldata, bytes calldata)
-        external
+    function _beforeSwap(address, PoolKey calldata key, IPoolManager.SwapParams calldata, bytes calldata)
+        internal
         override
         returns (bytes4, BeforeSwapDelta, uint24)
     {
@@ -189,8 +189,8 @@ contract SwapHook is BaseHook {
         return (BaseHook.beforeSwap.selector, BeforeSwapDeltaLibrary.ZERO_DELTA, 0);
     }
 
-    function afterSwap(address, PoolKey calldata key, IPoolManager.SwapParams calldata, BalanceDelta, bytes calldata)
-        external
+    function _afterSwap(address, PoolKey calldata key, IPoolManager.SwapParams calldata, BalanceDelta, bytes calldata)
+        internal
         override
         returns (bytes4, int128)
     {

--- a/docs/contracts/v4/quickstart/04-hooks/03-async-swap.mdx
+++ b/docs/contracts/v4/quickstart/04-hooks/03-async-swap.mdx
@@ -64,8 +64,8 @@ The funds' movements are as follows:
 contract AsyncSwapHook is BaseHook {
      // ...
 
-    function beforeSwap(address, PoolKey calldata key, IPoolManager.SwapParams calldata params, bytes calldata)
-        external
+    function _beforeSwap(address, PoolKey calldata key, IPoolManager.SwapParams calldata params, bytes calldata)
+        internal
         override
         returns (bytes4, BeforeSwapDelta, uint24)
     {

--- a/docs/contracts/v4/reference/core/types/beforeswapdelta-guide.mdx
+++ b/docs/contracts/v4/reference/core/types/beforeswapdelta-guide.mdx
@@ -168,12 +168,12 @@ This way, the actual amount swapped (99) reflects the fee taken by the hook, whi
 Here's how the `beforeSwap` hook might handle this:
 
 ```solidity
-function beforeSwap(
+function _beforeSwap(
     address,
     PoolKey calldata,
     IPoolManager.SwapParams calldata params,
     bytes calldata
-) external override returns (int256 amountIn, BeforeSwapDelta delta, uint24) {
+) internal override returns (int256 amountIn, BeforeSwapDelta delta, uint24) {
     int128 specifiedAmount = params.amountSpecified.toInt128();
     int128 fee = specifiedAmount / 100;  // 1% fee
     int128 adjustedAmount = specifiedAmount - fee;
@@ -320,12 +320,12 @@ When working with `BeforeSwapDelta`, consider the following best practices:
 Here's a simple example of how `BeforeSwapDelta` might be used in a `beforeSwap` hook:
 
 ```solidity
-function beforeSwap(
+function _beforeSwap(
     address,
     PoolKey calldata,
     IPoolManager.SwapParams calldata params,
     bytes calldata
-) external override returns (int256 amountIn, BeforeSwapDelta delta, uint24) {
+) internal override returns (int256 amountIn, BeforeSwapDelta delta, uint24) {
     // Convert the specified amount to int128
     int128 specifiedAmount = params.amountSpecified.toInt128();
     
@@ -357,12 +357,12 @@ This basic example doesn't modify the swap parameters or introduce any fees. It 
 For a more practical use case, here's an example that implements a simple fee mechanism:
 
 ```solidity
-function beforeSwap(
+function _beforeSwap(
     address,
     PoolKey calldata key,
     IPoolManager.SwapParams calldata params,
     bytes calldata
-) external override returns (int256 amountIn, BeforeSwapDelta delta, uint24) {
+) internal override returns (int256 amountIn, BeforeSwapDelta delta, uint24) {
     // Determine if this is a swap for token0 or token1
     bool zeroForOne = params.zeroForOne;
     


### PR DESCRIPTION
Re-uploading the changes due to some conflict merge messed up X_X

- use internal overrides in function signature instead of external for hook lifecycle e.g. `beforeSwap(...) internal override`
- update content reg importing `HookMiner` contract from `v4-periphery` instead of `v4-template`

@saucepoint please approve again 🫡