### PR TITLE
chore(bug): correct path for v3 sdk

### DIFF
--- a/docs/contracts/v3/guides/local-environment.mdx
+++ b/docs/contracts/v3/guides/local-environment.mdx
@@ -130,7 +130,7 @@ Compiled { x } Solidity files successfully
 
 When building and testing integrations with on chain protocols, developers often hit a problem: the liquidity on the live chain is critical to thoroughly testing their code but testing against a live network like Mainnet can be extremely expensive.
 
-See [the SDK getting started guide](../../../sdk/v3/guides/02-local-development) for a full example on how to use forks.
+See [the SDK getting started guide](../../../sdk/v3/guides/local-development) for a full example on how to use forks.
 
 With your local node up and running, you can use the `--network localhost` flag in tests to point the Hardhat testing suite to that local node:
 


### PR DESCRIPTION
Path for v3 sdk is broken. Gives 404.