### PR TITLE
fix: synchronize IPoolManager documentation with GitHub implementation

### DIFF
--- a/docs/contracts/v4/reference/core/IPoolManager.mdx
+++ b/docs/contracts/v4/reference/core/IPoolManager.mdx
@@ -20,7 +20,7 @@ Used in the `modifyLiquidity` function to add or remove liquidity from a specifi
 Structure used to execute a swap in a pool.
 
 - `zeroForOne`: Direction of the swap (true for token0 to token1, false for token1 to token0)
-- `amountSpecified`: Amount of tokens to swap (positive for exact input, negative for exact output)
+- `amountSpecified`: The desired input amount if negative (exactIn), or the desired output amount if positive (exactOut)
 - `sqrtPriceLimitX96`: Slippage limit represented as [Q64X96](https://uniswapv3book.com/milestone_3/more-on-fixed-point-numbers.html#:~:text=The%20Q64.,and%2018%20signify%20decimal%20places.) notation
 
 Used in the `swap` function to define the behavior of our swap.
@@ -95,7 +95,7 @@ Executes a swap against the given pool using the provided parameters.
 | params     | SwapParams | The parameters for executing the swap   |
 | hookData   | bytes      | Any data to pass to a hook contract on the before/afterSwap hooks     |
 
-Returns the balance delta for the address initiating the swap. Note swapping on low liquidity pools may cause unexpected amounts. Interacting with certain hooks may also alter the swap amounts.
+Returns the balance delta for the address initiating the swap. Swapping on low liquidity pools may cause unexpected swap amounts when liquidity available is less than amountSpecified. Additionally note that if interacting with hooks that have the BEFORE_SWAP_RETURNS_DELTA_FLAG or AFTER_SWAP_RETURNS_DELTA_FLAG, the hook may alter the swap input/output. Integrators should perform checks on the returned swapDelta.
 
 ## donate
 


### PR DESCRIPTION
This is a fix from dev support request:

The documentation and comment on amountSpecified in SwapParams in IPoolManager differ.
GitHub: https://github.com/Uniswap/v4-core/blob/80311e34080fee64b6fc6c916e9a51a437d0e482/src/interfaces/IPoolManager.sol#L149