### PR TITLE
fix: ipoolinitializerv4 reference

### DIFF
--- a/docs/contracts/v4/quickstart/01-create-pool.mdx
+++ b/docs/contracts/v4/quickstart/01-create-pool.mdx
@@ -108,8 +108,10 @@ PoolKey memory pool = PoolKey({
 ### 3. Encode the [`initializePool`](/contracts/v4/reference/periphery/base/PoolInitializer) parameters
 Pools are initialized with a starting price
 ```solidity
+import {IPoolInitializer_v4} from "v4-core/src/interfaces/IPoolInitializer_v4.sol";
+
 params[0] = abi.encodeWithSelector(
-    IPositionManager(positionManager).initializePool.selector,
+    IPoolInitializer_v4.initializePool.selector,
     pool,
     startingPrice
 );


### PR DESCRIPTION
Based on community request:

> I'm following these docs for create pool and add liquidity: https://docs.uniswap.org/contracts/v4/quickstart/create-pool
> but PositionManager.initializePool.selector doesnt exist
> has there been an update?
> 
> Member "initializePool" not found or not visible after argument-dependent lookup in type(contract PositionManager).
> i do see it on PoolInitializer_v4 which PositionManager inherits
> 
> MJC.