### PR TITLE
Fix getTokenTransferApproval method in 02-minting-position.md

### DIFF
--- a/docs/sdk/v3/guides/liquidity/02-minting-position.md
+++ b/docs/sdk/v3/guides/liquidity/02-minting-position.md
@@ -60,7 +60,7 @@ async function getTokenTransferApproval(address: string, amount: BigNumber) {
     const provider = new ethers.providers.JsonRpcProvider(rpcUrl)
 
     const tokenContract = new ethers.Contract(
-        token.address,
+        address,
         ERC20_ABI,
         provider
     )


### PR DESCRIPTION
Fixed wrong argument when instantiating a new token contract. The correct parameter is "address" instead of "token.address", according to the getTokenTransferApproval method firm.