### PR TITLE
docs: fix broken link to v4 documentation in hooks.md

### DIFF
--- a/docs/concepts/protocol/hooks.md
+++ b/docs/concepts/protocol/hooks.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 ## Introduction
 
-Uniswap v4 inherits all of the capital efficiency gains of Uniswap v3 while introducing major architectural improvements. 
+Uniswap v4 inherits all of the capital efficiency gains of Uniswap v3 while introducing major architectural improvements.
 
 The key innovations are the Hook System and Singleton Architecture, which together enable unprecedented protocol customization and gas optimization.
 
@@ -27,8 +27,8 @@ The hook system in v4 is built on top of a revolutionary architectural change kn
 - **Flash Accounting**: Token balances are tracked internally and settled at the end of transactions, minimizing transfers
 - **Native ETH Support**: Direct ETH trading without the need to wrap to WETH, improving user experience
 
-These core features are just the beginning of what's possible with Uniswap v4. 
+These core features are just the beginning of what's possible with Uniswap v4.
 
-To explore all features including flash accounting, native ETH support, dynamic fees, and custom accounting, check out the [v4 whitepaper](https://uniswap.org/whitepaper-v4.pdf). 
+To explore all features including flash accounting, native ETH support, dynamic fees, and custom accounting, check out the [v4 whitepaper](https://uniswap.org/whitepaper-v4.pdf).
 
-For technical implementations and detailed guides, visit the [v4 technical documentation](/contracts/v4/concepts/overview).
+For technical implementations and detailed guides, visit the [v4 technical documentation](/contracts/v4/overview).


### PR DESCRIPTION
This PR fixes a broken link in [https://docs.uniswap.org/concepts/protocol/hooks](https://docs.uniswap.org/concepts/protocol/hooks).

The original link at `v4 technical documentation` pointed to https://docs.uniswap.org/contracts/v4/concepts/overview
which results in a 404 Not Found error.
<img width="853" alt="image" src="https://github.com/user-attachments/assets/be3a3b15-f312-4a16-b4b7-3e2aa72c00df" />

It has been updated to the correct path:
https://docs.uniswap.org/contracts/v4/overview