### PR TITLE
fixed issue with example

### DIFF
--- a/docs/contracts/v4/guides/08-custom-accounting.mdx
+++ b/docs/contracts/v4/guides/08-custom-accounting.mdx
@@ -165,11 +165,7 @@ We use `poolManager.take` to collect the fee. This creates a debt for our hook i
 ```solidity
 Currency feeCurrency;
 
-if (params.zeroForOne) {
-    feeCurrency = params.amountSpecified < 0 ? key.currency0 : key.currency1;
-} else {
-    feeCurrency = params.amountSpecified < 0 ? key.currency1 : key.currency0;
-}
+feeCurrency = params.amountSpecified < 0 == params.zeroForOne ? key.currency0 : key.currency1;
 
 poolManager.take(feeCurrency, address(this), feeAmount);
 

--- a/docs/contracts/v4/guides/08-custom-accounting.mdx
+++ b/docs/contracts/v4/guides/08-custom-accounting.mdx
@@ -163,7 +163,14 @@ uint256 feeAmount = (swapAmount * HOOK_FEE_PERCENTAGE) / FEE_DENOMINATOR;
 We use `poolManager.take` to collect the fee. This creates a debt for our hook in the specified currency.
 
 ```solidity
-Currency feeCurrency = params.zeroForOne ? key.currency0 : key.currency1;
+Currency feeCurrency;
+
+if (params.zeroForOne) {
+    feeCurrency = params.amountSpecified < 0 ? key.currency0 : key.currency1;
+} else {
+    feeCurrency = params.amountSpecified < 0 ? key.currency1 : key.currency0;
+}
+
 poolManager.take(feeCurrency, address(this), feeAmount);
 
 ```


### PR DESCRIPTION
The  fee charging example was incorrect because it was charging the fee in currency0 when swap zeroForOne, while it should take into account the amountSpecified together with zeroForOne to determine the specifiedAmount thus feeAmount is in currency0 or currency1, then it should charge the corresponding currency to the user.