### PR TITLE
Code Fixes for the "Building Your First Hook" Guide Documentation

### DIFF
--- a/docs/contracts/v4/guides/hooks/01-your-first-hook.md
+++ b/docs/contracts/v4/guides/hooks/01-your-first-hook.md
@@ -179,7 +179,7 @@ Let’s make it so that our hook can mint some!
 
 ```solidity
 contract PointsHook is BaseHook {
-    PointsToken pointsToken;
+    PointsToken public pointsToken;
 
     constructor(IPoolManager _poolManager) BaseHook(_poolManager) {
         pointsToken = new PointsToken();
@@ -350,7 +350,7 @@ contract PointsHookTest is Test, Fixtures {
             IHooks(hook)
         );
         poolId = key.toId();
-        manager.initialize(key, SQRT_PRICE_1_1, ZERO_BYTES);
+        manager.initialize(key, SQRT_PRICE_1_1);
 
         // Provide full-range liquidity to the pool
         tickLower = TickMath.minUsableTick(key.tickSpacing);


### PR DESCRIPTION
I want to add a few corrections to the "Building Your First Hook" guide.  

Any developer who follows the guide and copies the code for reproduction will encounter the following issues:  

1. **PointsHook**: The `pointsToken` variable should be public.  
    ```solidity
    PointsToken pointsToken;
    ```  
    Currently, this variable is `internal` and cannot be read from outside the contract.  
    Later, when we insert the `PointsHookTest.t.sol`, the test will attempt to access the `pointsToken` variable:  
    
    ```solidity
    pointsToken = hook.pointsToken();
    ```  
    
    The `pointsToken` variable needs to be made **public** so that it can be accessed from the test.  

2. **PointsHookTest**: Incorrect interface usage  
    ```solidity
    manager.initialize(key, SQRT_PRICE_1_1, ZERO_BYTES);
    ```  
    
    However, the function expects two arguments, not three. The `ZERO_BYTES` argument is unnecessary and should be removed.