### PR TITLE
fix spelling issues 

### DIFF
--- a/docs/contracts/v1/guides/05-iframe-integration.md
+++ b/docs/contracts/v1/guides/05-iframe-integration.md
@@ -15,7 +15,7 @@ It can also be useful if your application requires users to acquire some token i
 
 # iframe vs. custom UI
 
-One benefit of an iframe integration is that the your site will automatically keep up with any improvements/additions to the v1.app.uniswap.org site. After the initital integration is setup no further work is needed to pull in updates as the exchange site is updated over time.
+One benefit of an iframe integration is that the your site will automatically keep up with any improvements/additions to the v1.app.uniswap.org site. After the initial integration is setup no further work is needed to pull in updates as the exchange site is updated over time.
 
 # Live Example
 

--- a/docs/contracts/v1/reference/03-interfaces.md
+++ b/docs/contracts/v1/reference/03-interfaces.md
@@ -78,7 +78,7 @@ interface UniswapExchangeInterface {
     function tokenToExchangeTransferInput(uint256 tokens_sold, uint256 min_tokens_bought, uint256 min_eth_bought, uint256 deadline, address recipient, address exchange_addr) external returns (uint256  tokens_bought);
     function tokenToExchangeSwapOutput(uint256 tokens_bought, uint256 max_tokens_sold, uint256 max_eth_sold, uint256 deadline, address exchange_addr) external returns (uint256  tokens_sold);
     function tokenToExchangeTransferOutput(uint256 tokens_bought, uint256 max_tokens_sold, uint256 max_eth_sold, uint256 deadline, address recipient, address exchange_addr) external returns (uint256  tokens_sold);
-    // ERC20 comaptibility for liquidity tokens
+    // ERC20 compatibility for liquidity tokens
     bytes32 public name;
     bytes32 public symbol;
     uint256 public decimals;

--- a/docs/contracts/v2/concepts/01-protocol-overview/02-ecosystem-participants.md
+++ b/docs/contracts/v2/concepts/01-protocol-overview/02-ecosystem-participants.md
@@ -11,7 +11,7 @@ In total, interactions between these classes create a positive feedback loop, fu
 
 # Liquidity Providers
 
-Liquidity providers, or LPs, are not a homogenous group:
+Liquidity providers, or LPs, are not a homogeneous group:
 
 - Passive LPs are token holders who wish to passively invest their assets to accumulate trading fees.
 

--- a/docs/contracts/v2/guides/interface-integration/03-iframe-integration.mdx
+++ b/docs/contracts/v2/guides/interface-integration/03-iframe-integration.mdx
@@ -19,7 +19,7 @@ It can also be useful if your application requires users to acquire some token i
 
 # iframe vs. custom UI
 
-One benefit of an iframe integration is that the your site will automatically keep up with any improvements/additions to the site. After the initital integration is setup no further work is needed to pull in updates as the exchange site is updated over time.
+One benefit of an iframe integration is that the your site will automatically keep up with any improvements/additions to the site. After the initial integration is setup no further work is needed to pull in updates as the exchange site is updated over time.
 
 # Example
 
@@ -46,7 +46,7 @@ To see the iframe, click the dropdown in the top right and click `Get FOAM`.
 
 # Add To Your Site
 
-To include a Uniswap iframe within your site just add an iframe element within your website code and link to the Uniswap frontent.
+To include a Uniswap iframe within your site just add an iframe element within your website code and link to the Uniswap frontend.
 
 Linking to a ETH &lt;-&gt; DAI swap page would look something like this. To link to a token of your choice replace the address after `outputCurrency` with the token address of the token you want to link to.
 


### PR DESCRIPTION
Hey team! Found and fixed minor errors:

docs/contracts/v1/guides/05-iframe-integration.md
- `initital` - `initial`

docs/contracts/v1/reference/03-interfaces.md
- `comaptibility` - `compatibility`

docs/contracts/v2/concepts/01-protocol-overview/02-ecosystem-participants.md
- `homogenous` - `homogeneous`

docs/contracts/v2/guides/interface-integration/03-iframe-integration.mdx
- `initital` - `initial`
- `frontent` - `frontend`