### PR TITLE
Fix path error on remappings

### DIFF
--- a/docs/contracts/v4/quickstart/03-swap.mdx
+++ b/docs/contracts/v4/quickstart/03-swap.mdx
@@ -27,7 +27,7 @@ In the `remappings.txt`, add the following:
 @uniswap/universal-router/=lib/universal-router/
 @uniswap/v3-core/=lib/v3-core/
 @uniswap/v2-core/=lib/v2-core/
-@openzeppelin/contracts/=lib/openzeppelin-contracts/
+@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/
 [...]
 ```
 


### PR DESCRIPTION
The remapping line for openzeppelin contracts has a missing folder on the path, this gives an error when copy the example on the Step `1: Set Up the Project` section down below.