### PR TITLE
Fix broken Uniswap V3 Book link in pool data guide

### DIFF
--- a/docs/sdk/v3/guides/advanced/02-pool-data.md
+++ b/docs/sdk/v3/guides/advanced/02-pool-data.md
@@ -99,7 +99,7 @@ Now that we have the address of a **USDC - ETH** Pool, we can construct an insta
 To construct the Contract we need to provide the address of the contract, its ABI and a provider connected to an [RPC endpoint](https://www.chainnodes.org/docs). We get access to the contract's ABI through the `@uniswap/v3-core` package, which holds the core smart contracts of the Uniswap V3 protocol:
 
 ```typescript
-import { ethers } from 'ethers
+import { ethers } from 'ethers'
 import IUniswapV3PoolABI from '@uniswap/v3-core/artifacts/contracts/interfaces/IUniswapV3Pool.sol/IUniswapV3Pool.json'
 
 const provider = getProvider()
@@ -263,7 +263,7 @@ const results: bigint[] = (await multicallProvider.all(calls)).map(
   )
 ```
 
-A great visualization of what the bitMaps look like can be found in the [Uniswap V3 development book](https://uniswapv3book.com/docs/milestone_2/tick-bitmap-index/):
+A great visualization of what the bitMaps look like can be found in the [Uniswap V3 development book](https://uniswapv3book.com/milestone_2/tick-bitmap-index.html):
 
 <img src={require('./images/tickBitmap_cut.png').default} alt="TickBitmap" box-shadow="none"/>
 


### PR DESCRIPTION
# Fix broken Uniswap V3 Book link in pool data guide

## Summary
This PR fixes a broken external link to the Uniswap V3 Book in the "Fetching Pool Data" guide.

## Problem
The link to the tick bitmap visualization in the Uniswap V3 Book was returning a 404 error due to URL structure changes on the external site.

## Changes
- Updated the broken link from `https://uniswapv3book.com/docs/milestone_2/tick-bitmap-index/` to `https://uniswapv3book.com/milestone_2/tick-bitmap-index.html`
- This ensures users can access the tick bitmap visualization content referenced in the guide

## Impact
- Fixes [Issue #991](https://github.com/Uniswap/docs/issues/991)
- Restores access to important visual content that helps users understand Uniswap V3's tick bitmap concept
- Improves user experience by eliminating broken links in the documentation