### PR TITLE
Fix broken background link in pool data guide

### DIFF
--- a/docs/sdk/v3/guides/advanced/02-pool-data.md
+++ b/docs/sdk/v3/guides/advanced/02-pool-data.md
@@ -8,7 +8,7 @@ title: Fetching Pool Data
 This guide will cover how to initialize a Pool with full tick data to allow offchain calculations. It is based on the [Fetching Pool data example](https://github.com/Uniswap/examples/tree/main/v3-sdk/pool-data), found in the Uniswap code examples [repository](https://github.com/Uniswap/examples). To run this example, check out the guide's [README](https://github.com/Uniswap/examples/blob/main/v3-sdk/pool-data/README.md) and follow the setup instructions.
 
 :::info
-If you need a briefer on the SDK and to learn more about how these guides connect to the examples repository, please visit our [background](./01-background.md) page!
+If you need a briefer on the SDK and to learn more about how these guides connect to the examples repository, please visit our [background](../01-background.md) page!
 :::
 
 In this example we will use **ethers JS** and **ethers-multicall** to construct a `Pool` object that we can use in the following guides.
@@ -99,7 +99,7 @@ Now that we have the address of a **USDC - ETH** Pool, we can construct an insta
 To construct the Contract we need to provide the address of the contract, its ABI and a provider connected to an [RPC endpoint](https://www.chainnodes.org/docs). We get access to the contract's ABI through the `@uniswap/v3-core` package, which holds the core smart contracts of the Uniswap V3 protocol:
 
 ```typescript
-import { ethers } from 'ethers
+import { ethers } from 'ethers'
 import IUniswapV3PoolABI from '@uniswap/v3-core/artifacts/contracts/interfaces/IUniswapV3Pool.sol/IUniswapV3Pool.json'
 
 const provider = getProvider()


### PR DESCRIPTION
# Fix broken background link in pool data guide

## Summary
This PR fixes a broken internal link to the background page in the "Fetching Pool Data" guide.

## Problem
The link to the background page was pointing to the wrong location due to incorrect relative path. The file structure shows that `01-background.md` is located in the parent directory `docs/sdk/v3/guides/`, but the link in `docs/sdk/v3/guides/advanced/02-pool-data.md` was using `./01-background.md` which would look in the current directory.

## Changes
- Updated the relative path from `./01-background.md` to `../01-background.md`
- This ensures the link correctly points to the background file in the parent directory

## Impact
- Fixes [Issue #990](https://github.com/Uniswap/docs/issues/990)
- Restores access to the background page which provides important SDK context
- Improves navigation flow for users reading the pool data guide
- Ensures users can access foundational information about the SDK and how guides connect to examples