### PR TITLE
Improve swap routing guide

### DIFF
--- a/docs/contracts/v4/guides/09-swap-routing.mdx
+++ b/docs/contracts/v4/guides/09-swap-routing.mdx
@@ -81,6 +81,8 @@ import { IV4Router } from "@uniswap/v4-periphery/src/interfaces/IV4Router.sol";
 import { Actions } from "@uniswap/v4-periphery/src/libraries/Actions.sol";
 import { IPermit2 } from "@uniswap/permit2/src/interfaces/IPermit2.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { StateLibrary } from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
+import { PoolKey } from "@uniswap/v4-core/src/types/PoolKey.sol";
 
 contract Example {
     using StateLibrary for IPoolManager;

--- a/docs/contracts/v4/guides/09-swap-routing.mdx
+++ b/docs/contracts/v4/guides/09-swap-routing.mdx
@@ -83,6 +83,7 @@ import { IPermit2 } from "@uniswap/permit2/src/interfaces/IPermit2.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { StateLibrary } from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
 import { PoolKey } from "@uniswap/v4-core/src/types/PoolKey.sol";
+import { Currency } from "@uniswap/v4-core/src/types/Currency.sol";
 
 contract Example {
     using StateLibrary for IPoolManager;
@@ -266,7 +267,7 @@ This prepares and executes the swap based on our encoded commands, actions, and 
 After the swap, we need to verify that we received at least the minimum amount of tokens we specified:
 
 ```solidity
-amountOut = IERC20(key.currency1).balanceOf(address(this));
+amountOut = IERC20(Currency.unwrap(key.currency1)).balanceOf(address(this));
 require(amountOut >= minAmountOut, "Insufficient output amount");
 ```
 
@@ -321,7 +322,7 @@ function swapExactInputSingle(
     router.execute(commands, inputs, deadline);
 
 // Verify and return the output amount
-    amountOut = IERC20(key.currency1).balanceOf(address(this));
+    amountOut = IERC20(Currency.unwrap(key.currency1)).balanceOf(address(this));
     require(amountOut >= minAmountOut, "Insufficient output amount");
     return amountOut;
 }

--- a/docs/contracts/v4/guides/09-swap-routing.mdx
+++ b/docs/contracts/v4/guides/09-swap-routing.mdx
@@ -74,7 +74,7 @@ We’ll create a new Solidity contract for our example.
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
-import { UniversalRouter } from "@uniswap/universal-router/contracts/UniversalRouter.sol";
+import { IUniversalRouter } from "@uniswap/universal-router/contracts/interfaces/IUniversalRouter.sol";
 import { Commands } from "@uniswap/universal-router/contracts/libraries/Commands.sol";
 import { IPoolManager } from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import { IV4Router } from "@uniswap/v4-periphery/src/interfaces/IV4Router.sol";
@@ -87,12 +87,12 @@ import { PoolKey } from "@uniswap/v4-core/src/types/PoolKey.sol";
 contract Example {
     using StateLibrary for IPoolManager;
 
-    UniversalRouter public immutable router;
+    IUniversalRouter public immutable router;
     IPoolManager public immutable poolManager;
     IPermit2 public immutable permit2;
 
     constructor(address _router, address _poolManager, address _permit2) {
-        router = UniversalRouter(_router);
+        router = IUniversalRouter(_router);
         poolManager = IPoolManager(_poolManager);
         permit2 = IPermit2(_permit2);
     }


### PR DESCRIPTION
This PR introduces improvements in three main areas of the guide:

1. **Missing imports:** The sample code was missing imports for `StateLibrary` and the `PoolKey` type, which are required for the code to compile correctly.

2. **Universal Router interface:** Replacing the direct contract instantiation with the `IUniversalRouter` interface solves the following Solidity error: `Explicit type conversion not allowed from non-payable "address" to "contract UniversalRouter", which has a payable fallback function. (solidity 7398)`
This also brings consistency with how other external contracts (`PoolManager`, `Permit2`) are handled via interfaces.

4. **Currency type unwrap:** Unwrapping `key.currency1` using the `Currency` type from `v4-core` fixes the following error: `Explicit type conversion not allowed from "Currency" to "contract IERC20". (solidity 9640)`
