### PR TITLE
Fix outdated imports and code samples

### DIFF
--- a/docs/sdk/v4/guides/swaps/01-quoting.md
+++ b/docs/sdk/v4/guides/swaps/01-quoting.md
@@ -28,6 +28,7 @@ We will first create an example configuration `CurrentConfig` in `config.ts`. Fo
 ```typescript
 import { SwapExactInSingle } from '@uniswap/v4-sdk'
 import { USDC_TOKEN, ETH_TOKEN } from './constants'
+import { parseUnits, JsonRpcProvider, formatUnits } from 'ethers'
 
 export const CurrentConfig: SwapExactInSingle = {
     poolKey: {
@@ -38,7 +39,7 @@ export const CurrentConfig: SwapExactInSingle = {
         hooks: "0x0000000000000000000000000000000000000000",
     },
     zeroForOne: true,
-    amountIn: ethers.utils.parseUnits('1', ETH_TOKEN.decimals).toString(), 
+    amountIn: parseUnits('1', ETH_TOKEN.decimals).toString(), 
     amountOutMinimum: "0",
     hookData: '0x00'
 }
@@ -51,7 +52,7 @@ Check out the top pools on [Uniswap](https://app.uniswap.org/#/pools).
 ```typescript
 import { Token, ChainId } from '@uniswap/sdk-core'
 
-const ETH_TOKEN = new Token(
+export const ETH_TOKEN = new Token(
   ChainId.MAINNET,
   '0x0000000000000000000000000000000000000000',
   18,
@@ -59,7 +60,7 @@ const ETH_TOKEN = new Token(
   'Ether'
 )
 
-const USDC_TOKEN = new Token(
+export const USDC_TOKEN = new Token(
   ChainId.MAINNET,
   '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
   6,
@@ -78,7 +79,7 @@ Now, we need to construct an instance of an **ethers** `Contract` for our Quoter
 const quoterContract = new ethers.Contract(
   QUOTER_CONTRACT_ADDRESS,
   QUOTER_ABI, // Import or define the ABI for Quoter contract
-  new ethers.providers.JsonRpcProvider("RPC") // Provide the right RPC address for the chain
+  new JsonRpcProvider("RPC") // Provide the right RPC address for the chain
 )
 ```
 
@@ -99,7 +100,7 @@ const quotedAmountOut = await quoterContract.callStatic.quoteExactInputSingle({
     hookData: CurrentConfig.hookData,
 })
 
-console.log(ethers.utils.formatUnits(quotedAmountOut.amountOut, USDC_TOKEN.decimals));
+console.log(formatUnits(quotedAmountOut.amountOut, USDC_TOKEN.decimals));
 ```
 
 The result of the call is the number of output tokens you would receive for the quoted swap.


### PR DESCRIPTION
ether.js used in the quote currently throws error due to new patches of update, this commit fixes that

### Description
There are new updates of ether.js over the years and the syntax has changed, henced why some syntax in uniswap doc will yell errors for programmers trying to implement it.. so this commit fix that

<!--- Summarize the changes that can be found in this PR and how your reviewers should test these changes. -->
- The `constant.ts` should have a proper `export ` command before defining the variables
- `ethers.js` has restructure a lot of their syntax, this new pr addresses and fixes that


### Motivation for PR
i am building a price aggregator and i wasted hours trying to make the code work unknown to me the doc is referencing an outdated doc..i dont want other dev to undergo same problem

### How Has This Been Tested?
now it works, i get the right quote!

