### PR TITLE
Update Ethereum-Deployments.md

### DIFF
--- a/docs/contracts/v3/reference/deployments/Ethereum-Deployments.md
+++ b/docs/contracts/v3/reference/deployments/Ethereum-Deployments.md
@@ -24,7 +24,7 @@ The latest version of `@uniswap/v3-core`, `@uniswap/v3-periphery`, and `@uniswap
 | [QuoterV2](https://github.com/Uniswap/v3-periphery/blob/main/contracts/lens/QuoterV2.sol)                                                                    | `0x61fFE014bA17989E743c5F6cB21bF9697530B21e` | `0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3` |
 | [SwapRouter02](https://github.com/Uniswap/swap-router-contracts/blob/main/contracts/SwapRouter02.sol)                                                        | `0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45` | `0x3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E` |
 | [Permit2](https://github.com/Uniswap/permit2)                                                                                                                | `0x000000000022D473030F116dDEE9F6B43aC78BA3` | `0x000000000022D473030F116dDEE9F6B43aC78BA3` |
-| [UniversalRouter](https://github.com/Uniswap/universal-router)                                                                                               | `0x66a9893cc07d91d95644aedd05d03f95e1dba8af` | `0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD` |
+| [UniversalRouter](https://github.com/Uniswap/universal-router)                                                                                               | `0x66a9893cc07d91d95644aedd05d03f95e1dba8af` | `0x3A9D48AB9751398BbFa63ad67599Bb04e4BdF98b` |
 | [v3StakerAddress](https://github.com/Uniswap/v3-staker)                                                                                                      | `0xe34139463bA50bD61336E0c446Bd8C0867c6fE65` | ``                                           |
 
 


### PR DESCRIPTION

### Description

<!--- Summarize the changes that can be found in this PR and how your reviewers should test these changes. -->
Updated UniversalRouter address on Sepoila from UniversalRouterV1 address to UniversalRouterV2 provided in its official repository: https://github.com/Uniswap/universal-router/blob/main/deploy-addresses/sepolia.json

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix
- [ ] New feature
- [x] Update to an existing feature

### Motivation for PR

<!--- If it addresses an open issue, please link to the issue here, otherwise, briefly describe the issue. -->

### How Has This Been Tested?

<!--- Please note how you have tested your changes. Browsers, accessibility, devices, unit tests, etc. -->

### Applicable screenshots

<!--- When appropriate, upload screenshots. -->

### Follow-up PR

<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
