### PR TITLE
Update overview.md

### DIFF
--- a/docs/contracts/the-compact/overview.md
+++ b/docs/contracts/the-compact/overview.md
@@ -54,9 +54,9 @@ The Compact is deployed at the same address across multiple chains:
 
 | Network | Address | 
 |---------|---------|
-| Ethereum Mainnet | `0x00000000000018DF021Ff2467dF97ff846E09f48` |
-| Base | `0x00000000000018DF021Ff2467dF97ff846E09f48` |
-| Unichain | `0x00000000000018DF021Ff2467dF97ff846E09f48` |
+| Ethereum Mainnet | `0x00000000000000171ede64904551eeDF3C6C9788` |
+| Base | `0x00000000000000171ede64904551eeDF3C6C9788` |
+| Unichain | `0x00000000000000171ede64904551eeDF3C6C9788` |
 
 > The Compact uses a deterministic deployment address, ensuring the same address across all supported networks.
 


### PR DESCRIPTION
fixing this because these are the old compact v0 addresses

### Description

Address for The Compact was incorrect. The correct address is: 

https://etherscan.io/address/0x00000000000000171ede64904551eeDF3C6C9788

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix
- [ ] New feature
- [X] Update to an existing feature

