### PR TITLE
Fix wrong universal router address in 03-multi-hop-swapping.md

### DIFF
--- a/docs/sdk/v4/guides/swaps/03-multi-hop-swapping.md
+++ b/docs/sdk/v4/guides/swaps/03-multi-hop-swapping.md
@@ -107,7 +107,7 @@ export function encodeMultihopExactInPath(
 We'll use the same contract addresses and ABIs from the single-hop guide and construct the **ethers** `Contract` for them:
 
 ```typescript
-const UNIVERSAL_ROUTER_ADDRESS = "0xf70536B3bcC1bD1a972dc186A2cf84cC6da6Be5D"
+const UNIVERSAL_ROUTER_ADDRESS = "0x66a9893cC07D91D95644AEDD05D03f95e1dBA8Af"
 const PERMIT2_ADDRESS = "0x000000000022D473030F116dDEE9F6B43aC78BA3"
 
 // ABIs remain the same as in single-hop guide


### PR DESCRIPTION
Fix wrong universal router address. The right address is [0x66a9893cc07d91d95644aedd05d03f95e1dba8af](https://etherscan.io/address/0x66a9893cc07d91d95644aedd05d03f95e1dba8af#code).

### Description

When i was using Claude cli i saw that he changed the address of the router in my code with this [https://etherscan.io/address/0xf70536B3bcC1bD1a972dc186A2cf84cC6da6Be5D](https://etherscan.io/address/0xf70536B3bcC1bD1a972dc186A2cf84cC6da6Be5D). This this let to some wrong transactions to the wrong address. It turn out the address in the doc was wrong.

### Type(s) of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Update to an existing feature

### How Has This Been Tested?

(https://etherscan.io/address/0x66a9893cc07d91d95644aedd05d03f95e1dba8af#code)
