### PR TITLE
docs: add Celo mainnet contract deployment addresses

### DIFF
--- a/docs/contracts/v4/deployments.mdx
+++ b/docs/contracts/v4/deployments.mdx
@@ -155,6 +155,17 @@ The latest version of `@uniswap/v4-core`, `@uniswap/v4-periphery`, and `@uniswap
 | [Universal Router](https://github.com/Uniswap/universal-router/blob/dev/contracts/UniversalRouter.sol) | [`0x1906c1d672b88cd1b9ac7593301ca990f94eae07`](https://bscscan.com/address/0x1906c1d672b88cd1b9ac7593301ca990f94eae07) |
 | [Permit2](https://github.com/Uniswap/permit2) | [`0x000000000022D473030F116dDEE9F6B43aC78BA3`](https://bscscan.com/address/0x000000000022D473030F116dDEE9F6B43aC78BA3) |
 
+### Celo: 42220
+| Contract | Address |
+|----------|---------|
+| [PoolManager](https://github.com/Uniswap/v4-core/blob/main/src/PoolManager.sol) | [`0x288dc841A52FCA2707c6947B3A777c5E56cd87BC`](https://celoscan.io/address/0x288dc841A52FCA2707c6947B3A777c5E56cd87BC) |
+| [PositionDescriptor](https://github.com/Uniswap/v4-periphery/blob/main/src/PositionDescriptor.sol) | [`0x5727E22b25fEEe05E8dFa83C752B86F19D102D8A`](https://celoscan.io/address/0x5727E22b25fEEe05E8dFa83C752B86F19D102D8A) |
+| [PositionManager](https://github.com/Uniswap/v4-periphery/blob/main/src/PositionManager.sol) | [`0xf7965f3981e4d5bc383bfbcb61501763e9068ca9`](https://celoscan.io/address/0xf7965f3981e4d5bc383bfbcb61501763e9068ca9) |
+| [Quoter](https://github.com/Uniswap/v4-periphery/blob/main/src/lens/V4Quoter.sol) | [`0x28566da1093609182dff2cb2a91cfd72e61d66cd`](https://celoscan.io/address/0x28566da1093609182dff2cb2a91cfd72e61d66cd) |
+| [StateView](https://github.com/Uniswap/v4-periphery/blob/main/src/lens/StateView.sol) | [`0xbc21f8720babf4b20d195ee5c6e99c52b76f2bfb`](https://celoscan.io/address/0xbc21f8720babf4b20d195ee5c6e99c52b76f2bfb) |
+| [Universal Router](https://github.com/Uniswap/universal-router/blob/dev/contracts/UniversalRouter.sol) | [`0xcb695bc5d3aa22cad1e6df07801b061a05a0233a`](https://celoscan.io/address/0xcb695bc5d3aa22cad1e6df07801b061a05a0233a) |
+| [Permit2](https://github.com/Uniswap/permit2) | [`0x000000000022D473030F116dDEE9F6B43aC78BA3`](https://celoscan.io/address/0x000000000022D473030F116dDEE9F6B43aC78BA3) |
+
 ## Testnet Deployments
 
 ### Unichain Sepolia: 1301


### PR DESCRIPTION
### Description

Added Uniswap V4 contract deployment addresses for Celo mainnet (chain ID: 42220) to the deployments documentation.

### Type(s) of changes

- [ ] Bug fix
- [x] New feature
- [ ] Update to an existing feature

### Motivation for PR

Adding official Celo mainnet deployment addresses for Uniswap V4 contracts to provide developers with accurate contract information for integration.

### Applicable screenshots

N/A - Documentation update only

### Follow-up PR

N/A