### PR TITLE
Update subgraph links

### DIFF
--- a/docs/contracts/v2/reference/API/01-overview.md
+++ b/docs/contracts/v2/reference/API/01-overview.md
@@ -7,7 +7,7 @@ This section explains the Uniswap Subgraph and how to interact with it. The Unis
 
 ## Resources
 
-[Subgraph Explorer](https://thegraph.com/explorer/subgraph/uniswap/uniswap-v2) - sandbox for querying data and endpoints for developers.
+[Subgraph Explorer](https://thegraph.com/explorer/profile/0xddaaed8b88ac0ccfdbfabdceba1c619391760f7f?view=Subgraphs&chain=arbitrum-one) - sandbox for querying data and endpoints for developers.
 
 [Uniswap V2 Subgraph](https://github.com/Uniswap/uniswap-v2-subgraph) - source code for deployed subgraph.
 
@@ -21,4 +21,4 @@ To learn more about querying a subgraph refer to [The Graph's documentation](htt
 
 ## Versions
 
-The [Uniswap V2 Subgraph](https://thegraph.com/explorer/subgraph/uniswap/uniswap-v2) only tracks data on Uniswap V2. For Uniswap V1 information see the [V1 Subgraph](https://thegraph.com/explorer/subgraph/graphprotocol/uniswap).
+The [Uniswap V2 Subgraph](https://thegraph.com/explorer/subgraphs/A3Np3RQbaBA6oKJgiwDJeo5T3zrYfGHPWFYayMwtNDum?view=Query&chain=arbitrum-one) only tracks data on Uniswap V2. For Uniswap V1 information see the [V1 Subgraph](https://thegraph.com/explorer/subgraphs/ESnjgAG9NjfmHypk4Huu4PVvz55fUwpyrRqHF21thoLJ?view=Query&chain=arbitrum-one).


### PR DESCRIPTION
### Description
Updates 3 subgraph links that are 404
Updates "Subgraph Explorer" link to graph subgraphs of subgraphs Updates v1 and v2 subgraph links to point directly to subgraph

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [x ] Bug fix
- [ ] New feature
- [ ] Update to an existing feature

### Motivation for PR

Bad links found

### How Has This Been Tested?

Tested locally

### Applicable screenshots

<img width="1380" height="912" alt="API_Overview___Uniswap" src="https://github.com/user-attachments/assets/4e4330bf-3051-4c6f-9b71-706fa0bbb5d1" />
<img width="1234" height="916" alt="API_Overview___Uniswap_and_GitHub_Desktop" src="https://github.com/user-attachments/assets/5d155030-3eff-48b1-bbe2-2362b5d48eb3" />
<img width="1226" height="911" alt="API_Overview___Uniswap_and_GitHub_Desktop_and_Token_Sniffer" src="https://github.com/user-attachments/assets/0d706c3e-5406-4c2c-a954-c61c11f3c0be" />


### Follow-up PR

<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
