### PR TITLE
fix(permit2): Better explain example witnessTypeString contents

### DIFF
--- a/docs/contracts/permit2/reference/signature-transfer.md
+++ b/docs/contracts/permit2/reference/signature-transfer.md
@@ -181,7 +181,7 @@ struct ExampleTrade {
 }
 ```
 
-Following EIP-712, the typehash for the data would be defined by:
+Following [EIP-712](https://eips.ethereum.org/EIPS/eip-712), the typehash for the data would be defined by:
 
 ```solidity
 bytes32 _EXAMPLE_TRADE_TYPEHASH = keccak256('ExampleTrade(address exampleTokenAddress,uint256 exampleMinimumAmountOut)');
@@ -200,7 +200,7 @@ And the `witnessTypeString` to be passed in should be:
 string constant witnessTypeString = "ExampleTrade(address exampleTokenAddress,uint256 exampleMinimumAmountOut)TokenPermissions(address token,uint256 amount)"
 ```
 
-It’s important to note that when hashing multiple typed structs, the ordering of the structs in the type string matters. Referencing EIP-721:
+It’s important to note that when hashing multiple typed structs, the ordering of the structs in the type string matters. Referencing [EIP-712](https://eips.ethereum.org/EIPS/eip-712):
 
 > If the struct type references other struct types (and these in turn reference even more struct types), then the set of referenced struct types is collected, sorted by name and appended to the encoding. An example encoding is `Transaction(Person from,Person to,Asset tx)Asset(address token,uint256 amount)Person(address wallet,string name)`
 > 

--- a/docs/contracts/permit2/reference/signature-transfer.md
+++ b/docs/contracts/permit2/reference/signature-transfer.md
@@ -170,9 +170,9 @@ function permitWitnessTransferFrom(
 - witnessTypeString - a string derived from the [EIP-712](https://eips.ethereum.org/EIPS/eip-712) encoding of a struct type that extends the above `PermitBatchTransferFrom` by adding a final member field for the data whose hash is in the `witness` parameter, starting from the representation of that final member and including `TokenPermissions` in correctly sorted position. See an example below.
 - signature - the signature over the permit data. Supports EOA signatures, compact signatures defined by [EIP-2098](https://eips.ethereum.org/EIPS/eip-2098), and contract signatures defined by [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271)
 
-**Example `permitWitnessTransferFrom` parameters**
+## Example `permitWitnessTransferFrom` parameters
 
-If an integrating contract would also like the signer to verify information about a trade, an integrating contract may ask the signer to also sign an `ExampleTrade` object that we define below:
+If an integrating contract would also like the signer to verify information about a trade, it may ask the signer to also sign an `ExampleTrade` object that we define below:
 
 ```solidity
 struct ExampleTrade {

--- a/docs/contracts/permit2/reference/signature-transfer.md
+++ b/docs/contracts/permit2/reference/signature-transfer.md
@@ -197,7 +197,7 @@ The `witness` that should be passed along with the permit message should be:
 And the `witnessTypeString` to be passed in should be:
 
 ```solidity
-string constant witnessTypeString = "ExampleTrade witness)ExampleTrade(address exampleTokenAddress,uint256 exampleMinimumAmountOut)TokenPermissions(address token,uint256 amount)"
+string constant witnessTypeString = "ExampleTrade(address exampleTokenAddress,uint256 exampleMinimumAmountOut)TokenPermissions(address token,uint256 amount)"
 ```
 
 It’s important to note that when hashing multiple typed structs, the ordering of the structs in the type string matters. Referencing EIP-721:

--- a/docs/contracts/permit2/reference/signature-transfer.md
+++ b/docs/contracts/permit2/reference/signature-transfer.md
@@ -143,7 +143,7 @@ function permitWitnessTransferFrom(
 - transferDetails constructed with same type as defined above in the single permitTransferFrom case
 - owner - the signer of the permit message and owner of the tokens
 - witness - arbitrary data passed through that was signed by the user. Is used to reconstruct the signature. Pass through this data if you want the permit signature recovery also to validate other data.
-- witnessTypeString - a string that defines the typed data that the witness was hashed from. It must also include the `TokenPermissions` struct and comply with [EIP-712](https://eips.ethereum.org/EIPS/eip-712) struct ordering. See an example below.
+- witnessTypeString - a string derived from the [EIP-712](https://eips.ethereum.org/EIPS/eip-712) encoding of a struct type that extends the above `PermitTransferFrom` by adding a final member field for the data whose hash is in the `witness` parameter, starting from the representation of that final member and including `TokenPermissions` in correctly sorted position. See an example below.
 - signature - the signature over the permit data. Supports EOA signatures, compact signatures defined by [EIP-2098](https://eips.ethereum.org/EIPS/eip-2098), and contract signatures defined by [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271)
 
 ### Batch `permitWitnessTransferFrom`
@@ -167,7 +167,7 @@ function permitWitnessTransferFrom(
 - transferDetails - constructed with the same type in the batched case of `permitTransferFrom`
 - owner - the signer of the permit message and owner of the tokens
 - witness - arbitrary data passed through that was signed by the user. Is used to reconstruct the signature. Pass through this data if you want the permit signature recovery to also validate other data.
-- witnessTypeString - a string that defines the typed data that the witness was hashed from. It must also include the `TokenPermissions` struct and comply with [EIP-712](https://eips.ethereum.org/EIPS/eip-712) struct ordering. See an example below.
+- witnessTypeString - a string derived from the [EIP-712](https://eips.ethereum.org/EIPS/eip-712) encoding of a struct type that extends the above `PermitBatchTransferFrom` by adding a final member field for the data whose hash is in the `witness` parameter, starting from the representation of that final member and including `TokenPermissions` in correctly sorted position. See an example below.
 - signature - the signature over the permit data. Supports EOA signatures, compact signatures defined by [EIP-2098](https://eips.ethereum.org/EIPS/eip-2098), and contract signatures defined by [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271)
 
 **Example `permitWitnessTransferFrom` parameters**
@@ -181,7 +181,7 @@ struct ExampleTrade {
 }
 ```
 
-Following [EIP-712](https://eips.ethereum.org/EIPS/eip-712), the typehash for the data would be defined by:
+Following [EIP-712](https://eips.ethereum.org/EIPS/eip-712), the typehash for ExampleTrade data would be defined by:
 
 ```solidity
 bytes32 _EXAMPLE_TRADE_TYPEHASH = keccak256('ExampleTrade(address exampleTokenAddress,uint256 exampleMinimumAmountOut)');
@@ -194,10 +194,15 @@ The `witness` that should be passed along with the permit message should be:
             abi.encode(_EXAMPLE_TRADE_TYPEHASH, exampleTrade.exampleTokenAddress, exampleTrade.exampleMinimumAmountOut));
 ```
 
-And the `witnessTypeString` to be passed in should be:
+The encoding of the struct type containing that witness would be something like
+```solidity
+string constant fullTypeString = "PermitWitnessTransferFrom(TokenPermissions permitted,uint256 nonce,uint256 deadline,ExampleTrade witness)ExampleTrade(address exampleTokenAddress,uint256 exampleMinimumAmountOut)TokenPermissions(address token,uint256 amount)"
+```
+
+And the `witnessTypeString` to be passed in should be the suffix of that encoding starting with the final top-level member:
 
 ```solidity
-string constant witnessTypeString = "ExampleTrade(address exampleTokenAddress,uint256 exampleMinimumAmountOut)TokenPermissions(address token,uint256 amount)"
+string constant witnessTypeString = "ExampleTrade witness)ExampleTrade(address exampleTokenAddress,uint256 exampleMinimumAmountOut)TokenPermissions(address token,uint256 amount)"
 ```
 
 It’s important to note that when hashing multiple typed structs, the ordering of the structs in the type string matters. Referencing [EIP-712](https://eips.ethereum.org/EIPS/eip-712):


### PR DESCRIPTION
### Description

Explain what otherwise looks like stray text in the `witnessTypeString` example at https://docs.uniswap.org/contracts/permit2/reference/signature-transfer#batch-permitwitnesstransferfrom , and fix some nearby references to EIP-712.

### Type(s) of changes

- [x] Bug fix
- [ ] New feature
- [ ] Update to an existing feature

### Motivation for PR

Explain example.

### How Has This Been Tested?

n/a

### Follow-up PR

Given the emphasis on proper ordering of struct types with the injection of a not-obviously-relevant TokenPermissions, it would be nice for the example entry-point type to actually reference some other structs. For example:
`````patch
 ```solidity
 struct ExampleTrade {
 	address exampleTokenAddress;
 	uint256 exampleMinimumAmountOut;
+	TradeCondition condition;
 }
+struct TradeCondition {
+	string language;
+	string expression;
+}
 ```
 Following EIP-712, the typehash for the data would be defined by:
 ```solidity
-bytes32 _EXAMPLE_TRADE_TYPEHASH = keccak256('ExampleTrade(address exampleTokenAddress,uint256 exampleMinimumAmountOut)');
+bytes32 _EXAMPLE_TRADE_TYPEHASH = keccak256('ExampleTrade(address exampleTokenAddress,uint256 exampleMinimumAmountOut,TradeCondition condition)TradeCondition(string language,string expression)');
 ```
 The `witness` that should be passed along with the permit message should be:
 ```solidity
  bytes32 witness = keccak256(
-            abi.encode(_EXAMPLE_TRADE_TYPEHASH, exampleTrade.exampleTokenAddress, exampleTrade.exampleMinimumAmountOut));
+            abi.encode(_EXAMPLE_TRADE_TYPEHASH, exampleTrade.exampleTokenAddress, exampleTrade.exampleMinimumAmountOut, exampleTrade.condition));
 ```
 And the `witnessTypeString` to be passed in should be:
 
 ```solidity
-string constant witnessTypeString = "ExampleTrade witness)ExampleTrade(address exampleTokenAddress,uint256 exampleMinimumAmountOut)TokenPermissions(address token,uint256 amount)"
+string constant witnessTypeString = "ExampleTrade witness)ExampleTrade(address exampleTokenAddress,uint256 exampleMinimumAmountOut,TradeCondition condition)TokenPermissions(address token,uint256 amount)TradeCondition(string language,string expression)"
`````