### PR TITLE
Update fee accrual explanation for Uniswap v4

### DIFF
--- a/docs/sdk/v4/guides/liquidity/collecting-fees.md
+++ b/docs/sdk/v4/guides/liquidity/collecting-fees.md
@@ -101,7 +101,7 @@ Total fees = Collected + Unclaimed
 
 ### Fee Accrual and Credit Changes
 
-**Fee Accrual and Credit:** Uniswap v4 changes how fee accrual is handled when modifying liquidity. In v3, adding or removing liquidity didn't automatically claim fees – you had to call a separate `collect` function to pull out accrued fees. In v4, **accrued fees act like a credit** that is automatically applied or required depending on liquidity changes. Increasing a position's liquidity will **roll any unclaimed fees into the position's liquidity**, and decreasing liquidity will **automatically withdraw** the proportional unclaimed fees for that position. This means that partially removing liquidity in v4 will force-claim the fees earned by that liquidity portion. However, if you want to claim fees without changing liquidity, you can perform a liquidity change of zero (as we'll do in this guide).
+**Fee Accrual and Credit:** Uniswap v4 changes how fee accrual is handled when modifying liquidity. In v3, adding or removing liquidity didn't automatically claim fees – you had to call a separate `collect` function to pull out accrued fees. In v4, **accrued fees act like a credit** that is automatically applied or required depending on liquidity changes. Increasing a position's liquidity will **roll any unclaimed fees into the position's liquidity**, and decreasing liquidity will **automatically withdraw** the position's unclaimed fees. However, if you want to claim fees without changing liquidity, you can perform a liquidity change of zero (as we'll do in this guide).
 
 ### Why StateView is Required
 


### PR DESCRIPTION
### Description

Clarified the behaviour of fee accrual and claims in Uniswap v4, emphasising automatic handling of unclaimed fees during liquidity changes.

After testing and exploration of the codebase, the previous message claims that the unclaimed fees are proportionally claimed based on what we remove from the LP position. But based on tests of part of the UNIV4 codebases, the full amount of unclaimed fees for that position is always gathered.


### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [X] Bug fix
- [ ] New feature
- [ ] Update to an existing feature

### Motivation for PR

No misleading in docs!

### How Has This Been Tested?

`Position.t.sol` tests confirm this, and then some tests we crafted on our own for the audit we are performing for codebase using UniV4
### Applicable screenshots

<!--- When appropriate, upload screenshots. -->

### Follow-up PR

<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
