### PR TITLE
Update protocol fee deployments addresses

### DIFF
--- a/docs/contracts/protocol-fee/deployments.mdx
+++ b/docs/contracts/protocol-fee/deployments.mdx
@@ -3,16 +3,23 @@ title: Deployments
 sidebar_position: 1.1
 ---
 
-# Deployment Addresses
+## Ethereum Mainnet 
 
-## Ethereum Mainnet
+| Contract | Address |
+|----------|---------|
+| MainnetDeployer | [0xd3Aa12B99892b7D95BBAA27AEf222A8E2a038C0C](https://etherscan.io/address/0xd3Aa12B99892b7D95BBAA27AEf222A8E2a038C0C) |
+| TokenJar (AssetSink) | [0xf38521f130fcCF29dB1961597bc5d2B60F995f85](https://etherscan.io/address/0xf38521f130fcCF29dB1961597bc5d2B60F995f85) |
+| Releaser (Firepit) | [0x0D5Cd355e2aBEB8fb1552F56c965B867346d6721](https://etherscan.io/address/0x0D5Cd355e2aBEB8fb1552F56c965B867346d6721) |
+| V3FeeAdapter | [0x5E74C9f42EEd283bFf3744fBD1889d398d40867d](https://etherscan.io/address/0x5E74C9f42EEd283bFf3744fBD1889d398d40867d) |
+| UNI | [0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984](https://etherscan.io/address/0x1f9840a85d5af5bf1d1762f925bdaddc4201f984) |
 
-| Contract        | Address                                                                                                               |
-|-----------------|-----------------------------------------------------------------------------------------------------------------------|
-| AssetSink       | 0xPLACEHOLDER_TBD                                                                                                     |
-| Firepit         | 0xPLACEHOLDER_TBD                                                                                                     |
-| V3FeeController | 0xPLACEHOLDER_TBD                                                                                                     |
-| UNI             | [0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984](https://etherscan.io/address/0x1f9840a85d5af5bf1d1762f925bdaddc4201f984) |
+## Unichain 
+
+| Contract | Address |
+|----------|---------|
+| UnichainDeployer | [0xD16c47bf3ae22e0B2BAc5925D990b81416f18dea](https://uniscan.xyz/address/0xD16c47bf3ae22e0B2BAc5925D990b81416f18dea) |
+| TokenJar | [0xD576BDF6b560079a4c204f7644e556DbB19140b5](https://uniscan.xyz/address/0xD576BDF6b560079a4c204f7644e556DbB19140b5) |
+| Releaser (OptimismBridgedResourceFirepit) | [0xe0A780E9105aC10Ee304448224Eb4A2b11A77eeB](https://uniscan.xyz/address/0xe0A780E9105aC10Ee304448224Eb4A2b11A77eeB) |
 
 ### Deployment Process
 


### PR DESCRIPTION
### Description

This PR updates the protocol fee deployments page by replacing placeholder addresses with the actual deployed contract addresses for both Ethereum Mainnet and Unichain. All contract addresses now include clickable links to Etherscan (for Mainnet) and Uniscan (for Unichain) for easy verification.

### Applicable screenshots

<img width="2952" height="1664" alt="image" src="https://github.com/user-attachments/assets/cb050468-aa99-47be-a83f-c84f6d8866d7" />

<img width="2946" height="1666" alt="image" src="https://github.com/user-attachments/assets/9ee7cc77-e648-40f9-85fd-789f84a86832" />

