### PR TITLE
docs: add MegaETH (chain 4326) deployment addresses for v2,v3 and v4

### DIFF
--- a/docs/contracts/v2/reference/smart-contracts/08-deployment-addresses.md
+++ b/docs/contracts/v2/reference/smart-contracts/08-deployment-addresses.md
@@ -20,3 +20,4 @@ Contract addresses for the [`Uniswap V2 Factory`](https://github.com/Uniswap/v2-
 | Zora                                                 | `0x0F797dC7efaEA995bB916f268D919d0a1950eE3C` | `0xa00F34A632630EFd15223B1968358bA4845bEEC7` |
 | WorldChain                                           | `0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f` | `0x541aB7c31A119441eF3575F6973277DE0eF460bd` |
 | Monad                                                | `0x182a927119d56008d921126764bf884221b10f59` | `0x4b2ab38dbf28d31d467aa8993f6c2585981d6804` |
+| MegaETH  | `0xbf56488c857a881ae7e3bed27cf99c10a7ab7e50` | `0xb73055db2B3A3EaE87a331DD88e4a80b43602690` |

--- a/docs/contracts/v3/reference/deployments/MegaETH-Deployments.md
+++ b/docs/contracts/v3/reference/deployments/MegaETH-Deployments.md
@@ -1,0 +1,49 @@
+---
+id: megaeth-deployments
+title: MegaETH Deployments
+---
+
+The latest version of `@uniswap/v3-core`, `@uniswap/v3-periphery`, and `@uniswap/swap-router-contracts` are deployed at the addresses listed below. Integrators should **no longer assume that they are deployed to the same addresses across chains** and be extremely careful to confirm mappings below.
+
+| Contract                                                                                                                                                     | MegaETH Addresses            |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------- |
+| [UniswapV3Factory](https://github.com/Uniswap/uniswap-v3-core/blob/v1.0.0/contracts/UniswapV3Factory.sol)                                                    | `0x3a5f0cd7d62452b7f899b2a5758bfa57be0de478` |
+| [UniswapInterfaceMulticall](https://megaeth.blockscout.com/address/0x61f3272a3619d9f20788c6822fed2e5471bfc477)                                                | `0x61f3272a3619d9f20788c6822fed2e5471bfc477` |
+| [TickLens](https://github.com/Uniswap/uniswap-v3-periphery/blob/v1.0.0/contracts/lens/TickLens.sol)                                                          | `0xe7a2d824722addcb21e7a203ae7b372bf3a29ec5` |
+| [NonfungiblePositionManager](https://github.com/Uniswap/uniswap-v3-periphery/blob/v1.0.0/contracts/NonfungiblePositionManager.sol)                           | `0xcdc86e98184e96436f733a8bf31bd4f0214e6d7d` |
+| [V3Migrator](https://github.com/Uniswap/uniswap-v3-periphery/blob/v1.0.0/contracts/V3Migrator.sol)                                                           | `0xed30f6c25fe915dc710f168fa3ab66199ee84454` |
+| [QuoterV2](https://github.com/Uniswap/v3-periphery/blob/main/contracts/lens/QuoterV2.sol)                                                                    | `0x31db60c6a4c71909674094b404597762df424ae7` |
+| [Quoter](https://github.com/Uniswap/uniswap-v3-periphery/blob/v1.0.0/contracts/lens/Quoter.sol)                                                              | `0x5affda77bc34d945f9632bd080ebfcf24133b90e` |
+| [SwapRouter](https://github.com/Uniswap/swap-router-contracts)                                                                                              | `0x2eec3eb1c9dc14af773e04a177f960124295a067` |
+| [SwapRouter02](https://github.com/Uniswap/swap-router-contracts/blob/main/contracts/SwapRouter02.sol)                                                      | `0x48020de9208bafc183f5cad5118ffbe8f0f913f5` |
+| [Permit2](https://github.com/Uniswap/permit2)                                                                                                                | `0x000000000022D473030F116dDEE9F6B43aC78BA3` |
+| [UniversalRouter](https://github.com/Uniswap/universal-router)                                                                                              | `0x47837eb80db5908eabba9105626d9b348bea7b02` |
+
+These addresses are final and were deployed from these npm package versions:
+
+- [`@uniswap/v3-core@1.0.0`](https://github.com/Uniswap/uniswap-v3-core/tree/v1.0.0)
+- [`@uniswap/v3-periphery@1.0.0`](https://github.com/Uniswap/uniswap-v3-periphery/tree/v1.0.0)
+- [`@uniswap/swap-router-contracts@1.1.0`](https://github.com/Uniswap/swap-router-contracts/tree/v1.1.0)
+
+
+## Universal Router
+
+The `UniversalRouter` contract is the current preferred entrypoint for ERC20 and NFT swaps, replacing, among other contracts, `SwapRouter02`. An up-to-date list of [deploy addresses by chain is hosted on GitHub](https://github.com/Uniswap/universal-router/tree/main/deploy-addresses).
+
+## Uniswap Pool Deployments
+
+Every Uniswap pool is a unique instance of the `UniswapV3Pool` contract and is deployed at its own unique address. The contract source code of the pool will be auto-verified on etherscan. For example, here is the [ETH/USDC 0.3% pool](https://etherscan.io/address/0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8) on Ethereum mainnet.
+
+You can look up the address of an existing pool on [Uniswap Info](https://info.uniswap.org/#/) or by calling the [`getPool`](../core/interfaces/IUniswapV3Factory.md#getpool) function on the `UniswapV3Factory` contract.
+
+```solidity
+getPool("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", 3000)
+```
+
+## Wrapped Native Token Addresses
+
+The Uniswap Protocol supports trading of ERC20 tokens. In order to swap a native asset like ETH (or MATIC on Polygon), the Uniswap protocol wraps these assets in an ERC20 wrapped native token contract. The protocol uses the following WETH9 addresses on Ethereum and WMATIC addresses on Polygon.
+
+| Network  | ChainId  | Wrapped Native Token | Address                                      |
+| -------- | -------- | -------------------- | -------------------------------------------- |
+| MegaETH  | `4326`   | WETH                 | `0x4200000000000000000000000000000000000006` |

--- a/docs/contracts/v3/reference/deployments/deployments.md
+++ b/docs/contracts/v3/reference/deployments/deployments.md
@@ -23,6 +23,7 @@ Please do not assume contracts are deployed to the same addresses across chains,
 - [`Zora`](./Zora-Deployments.md)
 - [`WorldChain`](./WorldChain-Deployments.md)
 - [`Monad`](./Monad-Deployments.md)
+- [`MegaETH`](./MegaETH-Deployments.md)
 
 These addresses are final and were deployed from these npm package versions:
 

--- a/docs/contracts/v4/deployments.mdx
+++ b/docs/contracts/v4/deployments.mdx
@@ -175,6 +175,17 @@ The latest version of `@uniswap/v4-core`, `@uniswap/v4-periphery`, and `@uniswap
 | [Universal Router](https://github.com/Uniswap/universal-router/blob/dev/contracts/UniversalRouter.sol) | [`0x0d97dc33264bfc1c226207428a79b26757fb9dc3`](https://monadvision.com/address/0x0d97dc33264bfc1c226207428a79b26757fb9dc3) |
 | [Permit2](https://github.com/Uniswap/permit2) | [`0x000000000022D473030F116dDEE9F6B43aC78BA3`](https://monadvision.com/address/0x000000000022D473030F116dDEE9F6B43aC78BA3) |
 
+### MegaETH: 4326
+| Contract | Address |
+|----------|---------|
+| [PoolManager](https://github.com/Uniswap/v4-core/blob/main/src/PoolManager.sol) | [`0xacb7e78fa05d562e0a5d3089ec896d57d057d38e`](https://megaeth.blockscout.com/address/0xacb7e78fa05d562e0a5d3089ec896d57d057d38e) |
+| [PositionDescriptor](https://github.com/Uniswap/v4-periphery/blob/main/src/PositionDescriptor.sol) | [`0xa9fdbb9d3dce2e1cfb91c4af1b8cf4ed62c0041a`](https://megaeth.blockscout.com/address/0xa9fdbb9d3dce2e1cfb91c4af1b8cf4ed62c0041a) |
+| [PositionManager](https://github.com/Uniswap/v4-periphery/blob/main/src/PositionManager.sol) | [`0x9ae0921e981aaa7308f176f8d4f9129b9247c89d`](https://megaeth.blockscout.com/address/0x9ae0921e981aaa7308f176f8d4f9129b9247c89d) |
+| [Quoter](https://github.com/Uniswap/v4-periphery/blob/main/src/lens/V4Quoter.sol) | [`0x94bdc671f0c35f44a1daa53143fd1f868d1623b9`](https://megaeth.blockscout.com/address/0x94bdc671f0c35f44a1daa53143fd1f868d1623b9) |
+| [StateView](https://github.com/Uniswap/v4-periphery/blob/main/src/lens/StateView.sol) | [`0x726f84e1dfb8d375a365e0808282f40d52d3e4e8`](https://megaeth.blockscout.com/address/0x726f84e1dfb8d375a365e0808282f40d52d3e4e8) |
+| [Universal Router](https://github.com/Uniswap/universal-router/blob/dev/contracts/UniversalRouter.sol) | [`0x48fd03529d2a91be835f07f6b72f53b4aad6093d`](https://megaeth.blockscout.com/address/0x48fd03529d2a91be835f07f6b72f53b4aad6093d) |
+| [Permit2](https://github.com/Uniswap/permit2) | [`0x000000000022D473030F116dDEE9F6B43aC78BA3`](https://megaeth.blockscout.com/address/0x000000000022D473030F116dDEE9F6B43aC78BA3) |
+
 ## Testnet Deployments
 
 ### Unichain Sepolia: 1301


### PR DESCRIPTION
### Description
add MegaETH (chain 4326) deployment addresses for v2,v3 and v4

### Applicable screenshots

<img width="1308" height="971" alt="Screenshot 2026-02-09 at 10 39 47 AM" src="https://github.com/user-attachments/assets/3079435f-a140-4f0b-af0d-dc6457f84b89" />
<img width="1415" height="771" alt="Screenshot 2026-02-09 at 10 50 24 AM" src="https://github.com/user-attachments/assets/835788b1-0691-48a0-a3e0-0382a148232d" />
<img width="1404" height="974" alt="Screenshot 2026-02-09 at 10 50 30 AM" src="https://github.com/user-attachments/assets/854c8f25-5074-4823-87b6-bcc00f933cb5" />
<img width="1084" height="800" alt="Screenshot 2026-02-09 at 11 00 29 AM" src="https://github.com/user-attachments/assets/1a07f270-f7ec-4026-8ea8-e422835e9460" />
