### PR TITLE
docs: fix BaseHook import path and setup instructions for v4 hooks

### DIFF
--- a/docs/contracts/v4/quickstart/hooks/setup.mdx
+++ b/docs/contracts/v4/quickstart/hooks/setup.mdx
@@ -3,7 +3,7 @@ title:  Set Up Local Environment
 sidebar_position: 0
 ---
 
-Before writing the hook let's first have a local environment properly configured e.g. deploying pool manager, utility routers and test tokens. 
+Before writing the hook let's first have a local environment properly configured e.g. deploying pool manager, utility routers and test tokens.
 
 At the end of this guide a development environment will be set up to be used to build the rest of the examples in the Guides section of the docs.
 
@@ -33,7 +33,7 @@ In the following sections, let's walk through the steps to create the same envir
 
 ### Setting up Foundry
 
-First thing is to set up a new Foundry project. 
+First thing is to set up a new Foundry project.
 
 If there is no Foundry installed - follow the [Foundry Book](https://book.getfoundry.sh/getting-started/installation) for installation.
 
@@ -47,7 +47,7 @@ cd counter-hook
 Then install the Uniswap `v4-core` and `v4-periphery` contracts as dependencies:
 
 ```bash
-forge install Uniswap/v4-core && forge install Uniswap/v4-periphery
+forge install Uniswap/v4-core && forge install Uniswap/v4-periphery && forge install OpenZeppelin/uniswap-hooks
 ```
 
 Next, set up the remappings so that the shorthand syntax for importing contracts from the dependencies work nicely:
@@ -60,6 +60,7 @@ forge remappings > remappings.txt
 
 ```
 @uniswap/v4-core/=lib/v4-core/
+@openzeppelin/uniswap-hooks/=lib/uniswap-hooks/
 forge-gas-snapshot/=lib/v4-core/lib/forge-gas-snapshot/src/
 forge-std/=lib/v4-core/lib/forge-std/src/
 permit2/=lib/v4-periphery/lib/permit2/
@@ -74,7 +75,7 @@ After that, remove the default Counter contract and its associated test and scri
 rm ./**/Counter*.sol
 ```
 
-Finally, since v4 uses transient storage which is only available after Ethereum's cancun hard fork and on Solidity versions >= 0.8.24 - some config must be set in `foundry.toml` config file. 
+Finally, since v4 uses transient storage which is only available after Ethereum's cancun hard fork and on Solidity versions >= 0.8.24 - some config must be set in `foundry.toml` config file.
 
 To do that, add the following lines to `foundry.toml`:
 
@@ -96,7 +97,7 @@ To confirm that the environment is configured correctly let's write a basic Coun
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import {BaseHook} from "v4-periphery/src/utils/BaseHook.sol";
+import {BaseHook} from "@openzeppelin/uniswap-hooks/src/base/BaseHook.sol";
 
 import {Hooks} from "v4-core/src/libraries/Hooks.sol";
 import {IPoolManager} from "v4-core/src/interfaces/IPoolManager.sol";


### PR DESCRIPTION
### Description

This PR updates the local environment setup guide for Uniswap v4 hooks to fix a broken BaseHook import. The documentation currently references BaseHook from v4-periphery, which is no longer available and causes compilation failures.

The guide now installs and references the official v4-hooks-public repository and updates remappings and import paths accordingly.

This ensures developers can successfully follow the setup instructions and compile the example hook contract without errors.

---
### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Update to an existing feature

---

### Motivation for PR

Following the current documentation results in a missing dependency error because BaseHook is no longer present in v4-periphery. This breaks the onboarding flow for developers trying to build hooks.

This PR restores a working setup path using the official hooks repository from openzeppelin and prevents confusion during initial environment configuration.

---

### How Has This Been Tested?

- Installed dependencies using the updated instructions
- Verified remappings resolve correctly
- Successfully compiled the example CounterHook contract with `forge build`
- Confirmed no import or dependency errors

---

### Applicable screenshots

N/A — documentation change only.

---

### Follow-up PR

None planned. Happy to adjust based on maintainer feedback.
