### PR TITLE
fix: address multiple documentation issues

### DIFF
--- a/docs/contracts/v3/guides/flash-integrations/flash-callback.md
+++ b/docs/contracts/v3/guides/flash-integrations/flash-callback.md
@@ -4,6 +4,10 @@ title: The Flash Callback
 sidebar_position: 3
 ---
 
+:::caution Security Warning
+The example contract inherits from `PeripheryPayments`, which exposes a public `sweepToken` function that allows **anyone** to withdraw ERC-20 tokens held by the contract. Do not leave token balances in the contract between transactions. Ensure all fund movements (deposit, swap, repay, profit withdrawal) happen atomically within the flash callback so that no tokens remain in the contract after execution. In a production contract, consider overriding `sweepToken` with access control or removing it entirely.
+:::
+
 ## Setting Up The Callback
 
 Here we will override the flash callback with our custom logic to execute the desired swaps and pay the profits to the original `msg.sender`.

--- a/docs/contracts/v4/guides/custom-accounting.mdx
+++ b/docs/contracts/v4/guides/custom-accounting.mdx
@@ -314,26 +314,36 @@ function _afterSwap(
         BalanceDelta delta,
         bytes calldata
     ) internal override returns (bytes4, int128) {
-        bool outputIsToken0 = params.zeroForOne ? false : true;
-
-        int256 outputAmount = outputIsToken0 ? delta.amount0() : delta.amount1();
-        if (outputAmount <= 0) {
-            return (BaseHook.afterSwap.selector, 0);
-        }
-
-        uint256 feeAmount = (uint256(outputAmount) * HOOK_FEE_PERCENTAGE) / FEE_DENOMINATOR;
-
-        require(feeAmount <= ((uint256(1) << 127) - 1), "fee too large");
-
         bool isExactIn = (params.amountSpecified < 0);
 
+        // Fee is taken in the unspecified currency:
+        //   exactIn  -> unspecified = output token
+        //   exactOut -> unspecified = input token
+        int256 unspecifiedAmount;
         Currency feeCurrency;
+
         if (isExactIn) {
+            // output is the unspecified currency
+            bool outputIsToken0 = params.zeroForOne ? false : true;
+            unspecifiedAmount = outputIsToken0 ? delta.amount0() : delta.amount1();
             feeCurrency = outputIsToken0 ? key.currency0 : key.currency1;
         } else {
+            // input is the unspecified currency
             bool inputIsToken0 = params.zeroForOne ? true : false;
+            unspecifiedAmount = inputIsToken0 ? delta.amount0() : delta.amount1();
             feeCurrency = inputIsToken0 ? key.currency0 : key.currency1;
         }
+
+        // For exactIn the output is positive; for exactOut the input is negative
+        // In both cases we take the absolute value of the unspecified amount
+        if (unspecifiedAmount == 0) {
+            return (BaseHook.afterSwap.selector, 0);
+        }
+        uint256 absAmount = unspecifiedAmount > 0 ? uint256(unspecifiedAmount) : uint256(-unspecifiedAmount);
+
+        uint256 feeAmount = (absAmount * HOOK_FEE_PERCENTAGE) / FEE_DENOMINATOR;
+
+        require(feeAmount <= ((uint256(1) << 127) - 1), "fee too large");
 
         poolManager.take(feeCurrency, address(this), feeAmount);
 
@@ -380,32 +390,38 @@ contract HookFeeAfterSwap is BaseHook {
     }
 
     function _afterSwap(
-        address ,
+        address,
         PoolKey calldata key,
         SwapParams calldata params,
         BalanceDelta delta,
         bytes calldata
     ) internal override returns (bytes4, int128) {
-        bool outputIsToken0 = params.zeroForOne ? false : true;
-
-        int256 outputAmount = outputIsToken0 ? delta.amount0() : delta.amount1();
-        if (outputAmount <= 0) {
-            return (BaseHook.afterSwap.selector, 0);
-        }
-
-        uint256 feeAmount = (uint256(outputAmount) * HOOK_FEE_PERCENTAGE) / FEE_DENOMINATOR;
-
-        require(feeAmount <= ((uint256(1) << 127) - 1), "fee too large");
-
         bool isExactIn = (params.amountSpecified < 0);
 
+        // Fee is taken in the unspecified currency:
+        //   exactIn  -> unspecified = output token
+        //   exactOut -> unspecified = input token
+        int256 unspecifiedAmount;
         Currency feeCurrency;
+
         if (isExactIn) {
+            bool outputIsToken0 = params.zeroForOne ? false : true;
+            unspecifiedAmount = outputIsToken0 ? delta.amount0() : delta.amount1();
             feeCurrency = outputIsToken0 ? key.currency0 : key.currency1;
         } else {
             bool inputIsToken0 = params.zeroForOne ? true : false;
+            unspecifiedAmount = inputIsToken0 ? delta.amount0() : delta.amount1();
             feeCurrency = inputIsToken0 ? key.currency0 : key.currency1;
         }
+
+        if (unspecifiedAmount == 0) {
+            return (BaseHook.afterSwap.selector, 0);
+        }
+        uint256 absAmount = unspecifiedAmount > 0 ? uint256(unspecifiedAmount) : uint256(-unspecifiedAmount);
+
+        uint256 feeAmount = (absAmount * HOOK_FEE_PERCENTAGE) / FEE_DENOMINATOR;
+
+        require(feeAmount <= ((uint256(1) << 127) - 1), "fee too large");
 
         poolManager.take(feeCurrency, address(this), feeAmount);
 

--- a/docs/sdk/v3/guides/advanced/02-pool-data.md
+++ b/docs/sdk/v3/guides/advanced/02-pool-data.md
@@ -207,10 +207,7 @@ We can calculate the minimum and maximum word from these indices and the Pool's 
 
 ```typescript
 function tickToWord(tick: number): number {
-  let compressed = Math.floor(tick / tickSpacing)
-  if (tick < 0 && tick % tickSpacing !== 0) {
-    compressed -= 1
-  }
+  const compressed = Math.floor(tick / tickSpacing)
   return compressed >> 8
 }
 

--- a/docs/sdk/v4/guides/swaps/multi-hop-swapping.md
+++ b/docs/sdk/v4/guides/swaps/multi-hop-swapping.md
@@ -53,7 +53,8 @@ export const CurrentConfig: SwapExactIn = {
         [ETH_USDC_POOL_KEY, USDC_USDT_POOL_KEY],
         ETH_TOKEN.address
     ),
-    amountIn: ethers.utils.parseUnits('1', ETH_TOKEN.decimals).toString(), 
+    maxHopSlippage: [], // Optional: per-hop slippage limits (one entry per hop). Empty array disables per-hop checks.
+    amountIn: ethers.utils.parseUnits('1', ETH_TOKEN.decimals).toString(),
     amountOutMinimum: "minAmountOut", // Change according to the slippage desired
 }
 ```


### PR DESCRIPTION
## Summary
- Fix afterSwap fee calculation to correctly use the unspecified currency for exact output swaps (fixes #1101)
- Add `maxHopSlippage` parameter to multi-hop swap guide (fixes #1086)
- Remove unnecessary `compressed -= 1` in `tickToWord` since `Math.floor` already rounds toward negative infinity (fixes #1066)
- Add security warning about `sweepToken` vulnerability in flash callback guide (fixes #949)

## Test plan
- [ ] Verify custom-accounting.mdx renders correctly and code examples are consistent
- [ ] Verify multi-hop-swapping.md renders correctly with new `maxHopSlippage` field
- [ ] Verify pool-data.md `tickToWord` function is correct
- [ ] Verify flash-callback.md caution admonition renders properly