### PR TITLE
docs: Add Tempo chain deployments across v2/v3/v4 docs and update LLM overview including pay-with-any-token skill

### DIFF
--- a/docs/builder-support/get-funded.mdx
+++ b/docs/builder-support/get-funded.mdx
@@ -12,7 +12,7 @@ Whether you’re playing with a new prototype or scaling your next venture, the 
 [The Uniswap Foundation](https://www.uniswapfoundation.org/), alongside key ecosystem contributors, offers structured grants and support pathways to help teams grow: from idea to impact. Each program is designed to meet you where you are, with a clear path to level up as you build.
 
 <Cards>
-  <Card title="Unichain Grants" href="#unichain-grants" />
+  <Card title="Uniswap Foundation Grants" href="#uniswap-foundation-grants" />
   <Card title="Uniswap Hook Incubator" href="#uniswap-hook-incubator" />
   <Card title="v4 Hooks Support" href="#v4-hooks-support" />
   <Card title="UFSF Audit Subsidies" href="#ufsf-audit-subsidies" />
@@ -32,15 +32,16 @@ Whether you’re playing with a new prototype or scaling your next venture, the 
 
     Share early data and qualitative user feedback to strengthen your application!
 
-## Unichain Grants
+## Uniswap Foundation Grants
 
-Unichain DeFi projects with $250K+ TVL and infrastructure projects can apply for product and GTM support, with up to $7.5K in grants funding.
+The Uniswap Foundation funds projects across the ecosystem: protocols, tooling, research, governance, and community. Apply to be evaluated for grants and additional support.
 
-[Apply for Unichain Grant support](https://share.hsforms.com/18Kv3hTvDSt-x1wK9va0OYwsdca9)
+[Apply for Uniswap Foundation Grants](https://share.hsforms.com/1fxQjPQTgTYmPwlYxxKlSGQsdca9)
 
 **What you get:**
-- Grant range: up to $7.5K USD
-- Application type: DeFi or infrastructure projects
+- Funding based on project scope and needs
+- Technical resources and ecosystem connections
+- Strategic support: partnerships, distribution, and guidance
 
 ## Uniswap Hook Incubator
 

--- a/docs/contracts/v2/reference/smart-contracts/08-deployment-addresses.md
+++ b/docs/contracts/v2/reference/smart-contracts/08-deployment-addresses.md
@@ -11,6 +11,7 @@ Contract addresses for the [`Uniswap V2 Factory`](https://github.com/Uniswap/v2-
 | Sepolia                                              | `0xF62c03E08ada871A0bEb309762E260a7a6a880E6` | `0xeE567Fe1712Faf6149d80dA1E6934E354124CfE3` |
 | Unichain                                             | `0x1f98400000000000000000000000000000000002` | `0x284f11109359a7e1306c3e447ef14d38400063ff` |
 | Arbitrum                                             | `0xf1D7CC64Fb4452F05c498126312eBE29f30Fbcf9` | `0x4752ba5dbc23f44d87826276bf6fd6b1c372ad24` |
+| Tempo                                                | `0xf9ec577a4e45b5278bb7cf60fcbc20c3acaef68f` | `0x0fbac3c46f6f83b44c7fb4ea986d7309c701d73e` |
 | Avalanche                                            | `0x9e5A52f57b3038F1B8EeE45F28b3C1967e22799C` | `0x4752ba5dbc23f44d87826276bf6fd6b1c372ad24` |
 | BNB Chain                                            | `0x8909Dc15e40173Ff4699343b6eB8132c65e18eC6` | `0x4752ba5DBc23f44D87826276BF6Fd6b1C372aD24` |
 | Base                                                 | `0x8909Dc15e40173Ff4699343b6eB8132c65e18eC6` | `0x4752ba5dbc23f44d87826276bf6fd6b1c372ad24` |

--- a/docs/contracts/v3/reference/deployments/Tempo-Deployments.md
+++ b/docs/contracts/v3/reference/deployments/Tempo-Deployments.md
@@ -1,0 +1,41 @@
+---
+id: tempo-deployments
+title: Tempo Deployments
+---
+
+The latest version of `@uniswap/v3-core`, `@uniswap/v3-periphery`, and `@uniswap/swap-router-contracts` are deployed at the addresses listed below. Integrators should **no longer assume that they are deployed to the same addresses across chains** and be extremely careful to confirm mappings below.
+
+| Contract                                                                                                                                                     | Tempo Addresses                             |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------- |
+| [UniswapV3Factory](https://github.com/Uniswap/uniswap-v3-core/blob/v1.0.0/contracts/UniswapV3Factory.sol)                                                    | `0x24a3d4757e330890a8b8978028c9e58e04611fd6` |
+| [UniswapInterfaceMulticall](https://github.com/Uniswap/v3-periphery/blob/main/contracts/lens/UniswapInterfaceMulticall.sol)                                  | `0x64eb6294fd6072b2c20d31a54e39d5d3bf69d982` |
+| [TickLens](https://github.com/Uniswap/uniswap-v3-periphery/blob/v1.0.0/contracts/lens/TickLens.sol)                                                          | `0x95cb27f323a03b03528096a527ee75704db28ef5` |
+| [NonfungiblePositionManager](https://github.com/Uniswap/uniswap-v3-periphery/blob/v1.0.0/contracts/NonfungiblePositionManager.sol)                           | `0xb71c33f096ceabdc0229110e0d76a6382d01c633` |
+| [V3Migrator](https://github.com/Uniswap/uniswap-v3-periphery/blob/v1.0.0/contracts/V3Migrator.sol)                                                           | `0x2352328bd3313549d6d908646c82c2b7136901a9` |
+| [QuoterV2](https://github.com/Uniswap/v3-periphery/blob/main/contracts/lens/QuoterV2.sol)                                                                    | `0x53ab5d7a69db158f621b43ee70423da1e1403c2a` |
+| [Quoter](https://github.com/Uniswap/uniswap-v3-periphery/blob/v1.0.0/contracts/lens/Quoter.sol)                                                              | `0x9a0dd5fda50d8df9dd6fa4b4be33b6b1e241b408` |
+| [SwapRouter](https://github.com/Uniswap/swap-router-contracts)                                                                                              | `0x6a3988d2366ad79917a2399f18a1a82b157470e1` |
+| [SwapRouter02](https://github.com/Uniswap/swap-router-contracts/blob/main/contracts/SwapRouter02.sol)                                                      | `0x7e9d53081e961201837336bcd81f52ae92691a8f` |
+| [Permit2](https://github.com/Uniswap/permit2)                                                                                                                | `0x000000000022D473030F116dDEE9F6B43aC78BA3` |
+| [UniversalRouter](https://github.com/Uniswap/universal-router)                                                                                              | `0xa2dc7d0266f0cc50b3eeaf36c9bfcecff1beea91` |
+
+These addresses are final and were deployed from these npm package versions:
+
+- [`@uniswap/v3-core@1.0.0`](https://github.com/Uniswap/uniswap-v3-core/tree/v1.0.0)
+- [`@uniswap/v3-periphery@1.0.0`](https://github.com/Uniswap/uniswap-v3-periphery/tree/v1.0.0)
+- [`@uniswap/swap-router-contracts@1.1.0`](https://github.com/Uniswap/swap-router-contracts/tree/v1.1.0)
+
+
+## Universal Router
+
+The `UniversalRouter` contract is the current preferred entrypoint for ERC20 and NFT swaps, replacing, among other contracts, `SwapRouter02`. An up-to-date list of [deploy addresses by chain is hosted on GitHub](https://github.com/Uniswap/universal-router/tree/main/deploy-addresses).
+
+## Uniswap Pool Deployments
+
+Every Uniswap pool is a unique instance of the `UniswapV3Pool` contract and is deployed at its own unique address. The contract source code of the pool will be auto-verified on etherscan. For example, here is the [ETH/USDC 0.3% pool](https://etherscan.io/address/0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8) on Ethereum mainnet.
+
+You can look up the address of an existing pool on [Uniswap Info](https://info.uniswap.org/#/) or by calling the [`getPool`](../core/interfaces/IUniswapV3Factory.md#getpool) function on the `UniswapV3Factory` contract.
+
+```solidity
+getPool("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", 3000)
+```

--- a/docs/contracts/v3/reference/deployments/deployments.md
+++ b/docs/contracts/v3/reference/deployments/deployments.md
@@ -12,6 +12,7 @@ Please do not assume contracts are deployed to the same addresses across chains,
 - [`Ethereum`](./Ethereum-Deployments.md)
 - [`Unichain`](./Unichain-Deployments.md)
 - [`Arbitrum`](./Arbitrum-Deployments.md)
+- [`Tempo`](./Tempo-Deployments.md)
 - [`Optimism`](./Optimism-Deployments.md)
 - [`Polygon`](./Polygon-Deployments.md)
 - [`Base`](./Base-Deployments.md)

--- a/docs/contracts/v4/deployments.mdx
+++ b/docs/contracts/v4/deployments.mdx
@@ -65,6 +65,17 @@ The latest version of `@uniswap/v4-core`, `@uniswap/v4-periphery`, and `@uniswap
 | [Universal Router](https://github.com/Uniswap/universal-router/blob/dev/contracts/UniversalRouter.sol) | [`0xa51afafe0263b40edaef0df8781ea9aa03e381a3`](https://arbiscan.io/address/0xa51afafe0263b40edaef0df8781ea9aa03e381a3) |
 | [Permit2](https://github.com/Uniswap/permit2) | [`0x000000000022D473030F116dDEE9F6B43aC78BA3`](https://arbiscan.io/address/0x000000000022D473030F116dDEE9F6B43aC78BA3) |
 
+### Tempo: 4217
+| Contract | Address |
+|----------|---------|
+| [PoolManager](https://github.com/Uniswap/v4-core/blob/main/src/PoolManager.sol) | [`0x33620f62c5b9b2086dd6b62f4a297a9f30347029`](https://explore.tempo.xyz/address/0x33620f62c5b9b2086dd6b62f4a297a9f30347029) |
+| [PositionDescriptor](https://github.com/Uniswap/v4-periphery/blob/main/src/PositionDescriptor.sol) | [`0xc73ed2cba8c347593d1d9120aa0be8ff88c6ff77`](https://explore.tempo.xyz/address/0xc73ed2cba8c347593d1d9120aa0be8ff88c6ff77) |
+| [PositionManager](https://github.com/Uniswap/v4-periphery/blob/main/src/PositionManager.sol) | [`0x3fc79444f8eacc1894775493ff3fa41f1e35ce11`](https://explore.tempo.xyz/address/0x3fc79444f8eacc1894775493ff3fa41f1e35ce11) |
+| [Quoter](https://github.com/Uniswap/v4-periphery/blob/main/src/lens/V4Quoter.sol) | [`0x20e6487c371a2086f841ef453f85378223df4f4e`](https://explore.tempo.xyz/address/0x20e6487c371a2086f841ef453f85378223df4f4e) |
+| [StateView](https://github.com/Uniswap/v4-periphery/blob/main/src/lens/StateView.sol) | [`0x21b954fba3f5ddebe77ef2d47a3100c066908b2a`](https://explore.tempo.xyz/address/0x21b954fba3f5ddebe77ef2d47a3100c066908b2a) |
+| [Universal Router](https://github.com/Uniswap/universal-router/blob/dev/contracts/UniversalRouter.sol) | [`0xa2dc7d0266f0cc50b3eeaf36c9bfcecff1beea91`](https://explore.tempo.xyz/address/0xa2dc7d0266f0cc50b3eeaf36c9bfcecff1beea91) |
+| [Permit2](https://github.com/Uniswap/permit2) | [`0x000000000022D473030F116dDEE9F6B43aC78BA3`](https://explore.tempo.xyz/address/0x000000000022D473030F116dDEE9F6B43aC78BA3) |
+
 ### Polygon: 137
 | Contract | Address |
 |----------|---------|

--- a/docs/llms/overview.md
+++ b/docs/llms/overview.md
@@ -22,7 +22,7 @@ Uniswap provides AI-powered development tools that help you integrate swaps, bui
 
 | Plugin | Description |
 | --- | --- |
-| **uniswap-trading** | Integrate swaps via [Trading API](https://developers.uniswap.org/dashboard), Universal Router SDK, or direct contract calls. |
+| **uniswap-trading** | Integrate swaps via the [Uniswap API](https://developers.uniswap.org/dashboard), Universal Router SDK, or direct contract calls. Includes the `pay-with-any-token` skill for 402 challenge (supports x402 and MPP). |
 | **uniswap-hooks** | Security-first guidance for building Uniswap v4 hooks. |
 | **uniswap-viem** | EVM integration with viem and wagmi. |
 | **uniswap-driver** | Token discovery and swap/liquidity planning with deep links. |
@@ -46,7 +46,7 @@ If you use [Claude Code](https://claude.ai/code), first add the Uniswap marketpl
 
 # Install individual plugins
 claude plugin add uniswap-hooks     # v4 hook development
-claude plugin add uniswap-trading   # Swap integration
+claude plugin add uniswap-trading   # Swap integration (+ pay-with-any-token skill)
 claude plugin add uniswap-viem      # EVM / viem / wagmi
 claude plugin add uniswap-driver    # Token discovery & deep links
 claude plugin add uniswap-cca       # CCA auction configuration


### PR DESCRIPTION
## Summary

- Added Tempo (chain ID 4217) deployment information in:
  - `docs/contracts/v2/reference/smart-contracts/08-deployment-addresses.md`
  - `docs/contracts/v4/deployments.mdx`
  - `docs/contracts/v3/reference/deployments/deployments.md`
  - `docs/contracts/v3/reference/deployments/Tempo-Deployments.md` (new)
- Added Tempo explorer links (`https://explore.tempo.xyz/address/<address>`) to the Tempo section in v4 deployments for consistency.
- Updated `docs/llms/overview.md` so `pay-with-any-token` is documented as part of `uniswap-trading` in the plugin table and install snippet.
