### PR TITLE
docs: standardize v3 deployment explorer copy across chain pages

### DIFF
--- a/docs/contracts/v3/reference/deployments/AVAX-Deployments.md
+++ b/docs/contracts/v3/reference/deployments/AVAX-Deployments.md
@@ -40,9 +40,9 @@ The `UniversalRouter` contract is the current preferred entrypoint for ERC20 and
 
 ## Uniswap Pool Deployments
 
-Every Uniswap pool is a unique instance of the `UniswapV3Pool` contract and is deployed at its own unique address. The contract source code of the pool will be auto-verified on etherscan. For example, here is the [ETH/USDC 0.3% pool](https://etherscan.io/address/0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8) on Ethereum mainnet.
+Every Uniswap pool is a unique instance of the `UniswapV3Pool` contract and is deployed at its own unique address. The contract source code of the pool will be auto-verified on the [Snowtrace](https://snowtrace.io/) explorer.
 
-You can look up the address of an existing pool on [Uniswap Info](https://info.uniswap.org/#/) or by calling the [`getPool`](../core/interfaces/IUniswapV3Factory.md#getpool) function on the `UniswapV3Factory` contract.
+You can look up the address of an existing pool on [Uniswap Info](https://app.uniswap.org/explore#/) or by calling the [`getPool`](../core/interfaces/IUniswapV3Factory.md#getpool) function on the `UniswapV3Factory` contract.
 
 ```solidity
 getPool("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", 3000)

--- a/docs/contracts/v3/reference/deployments/Arbitrum-Deployments.md
+++ b/docs/contracts/v3/reference/deployments/Arbitrum-Deployments.md
@@ -41,9 +41,9 @@ The `UniversalRouter` contract is the current preferred entrypoint for ERC20 and
 
 ## Uniswap Pool Deployments
 
-Every Uniswap pool is a unique instance of the `UniswapV3Pool` contract and is deployed at its own unique address. The contract source code of the pool will be auto-verified on etherscan. For example, here is the [ETH/USDC 0.3% pool](https://etherscan.io/address/0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8) on Ethereum mainnet.
+Every Uniswap pool is a unique instance of the `UniswapV3Pool` contract and is deployed at its own unique address. The contract source code of the pool will be auto-verified on the [Arbitrum Explorer](https://arbiscan.io/).
 
-You can look up the address of an existing pool on [Uniswap Info](https://info.uniswap.org/#/) or by calling the [`getPool`](../core/interfaces/IUniswapV3Factory.md#getpool) function on the `UniswapV3Factory` contract.
+You can look up the address of an existing pool on [Uniswap Info](https://app.uniswap.org/explore#/) or by calling the [`getPool`](../core/interfaces/IUniswapV3Factory.md#getpool) function on the `UniswapV3Factory` contract.
 
 ```solidity
 getPool("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", 3000)

--- a/docs/contracts/v3/reference/deployments/BNB-Binance-Deployments.md
+++ b/docs/contracts/v3/reference/deployments/BNB-Binance-Deployments.md
@@ -39,9 +39,9 @@ The `UniversalRouter` contract is the current preferred entrypoint for ERC20 and
 
 ## Uniswap Pool Deployments
 
-Every Uniswap pool is a unique instance of the `UniswapV3Pool` contract and is deployed at its own unique address. The contract source code of the pool will be auto-verified on etherscan. For example, here is the [ETH/USDC 0.3% pool](https://etherscan.io/address/0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8) on Ethereum mainnet.
+Every Uniswap pool is a unique instance of the `UniswapV3Pool` contract and is deployed at its own unique address. The contract source code of the pool will be auto-verified on the [BscScan](https://bscscan.com/).
 
-You can look up the address of an existing pool on [Uniswap Info](https://info.uniswap.org/#/) or by calling the [`getPool`](../core/interfaces/IUniswapV3Factory.md#getpool) function on the `UniswapV3Factory` contract.
+You can look up the address of an existing pool on [Uniswap Info](https://app.uniswap.org/explore#/) or by calling the [`getPool`](../core/interfaces/IUniswapV3Factory.md#getpool) function on the `UniswapV3Factory` contract.
 
 ```solidity
 getPool("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", 3000)

--- a/docs/contracts/v3/reference/deployments/Base-Deployments.md
+++ b/docs/contracts/v3/reference/deployments/Base-Deployments.md
@@ -39,9 +39,9 @@ The `UniversalRouter` contract is the current preferred entrypoint for ERC20 and
 
 ## Uniswap Pool Deployments
 
-Every Uniswap pool is a unique instance of the `UniswapV3Pool` contract and is deployed at its own unique address. The contract source code of the pool will be auto-verified on etherscan. For example, here is the [ETH/USDC 0.3% pool](https://etherscan.io/address/0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8) on Ethereum mainnet.
+Every Uniswap pool is a unique instance of the `UniswapV3Pool` contract and is deployed at its own unique address. The contract source code of the pool will be auto-verified on the [BaseScan](https://basescan.org/).
 
-You can look up the address of an existing pool on [Uniswap Info](https://info.uniswap.org/#/) or by calling the [`getPool`](../core/interfaces/IUniswapV3Factory.md#getpool) function on the `UniswapV3Factory` contract.
+You can look up the address of an existing pool on [Uniswap Info](https://app.uniswap.org/explore#/) or by calling the [`getPool`](../core/interfaces/IUniswapV3Factory.md#getpool) function on the `UniswapV3Factory` contract.
 
 ```solidity
 getPool("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", 3000)

--- a/docs/contracts/v3/reference/deployments/Blast-Deployments.md
+++ b/docs/contracts/v3/reference/deployments/Blast-Deployments.md
@@ -36,9 +36,9 @@ The `UniversalRouter` contract is the current preferred entrypoint for ERC20 and
 
 ## Uniswap Pool Deployments
 
-Every Uniswap pool is a unique instance of the `UniswapV3Pool` contract and is deployed at its own unique address. The contract source code of the pool will be auto-verified on etherscan. For example, here is the [ETH/USDC 0.3% pool](https://etherscan.io/address/0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8) on Ethereum mainnet.
+Every Uniswap pool is a unique instance of the `UniswapV3Pool` contract and is deployed at its own unique address. The contract source code of the pool will be auto-verified on the [Blastscan](https://blastscan.io/).
 
-You can look up the address of an existing pool on [Uniswap Info](https://info.uniswap.org/#/) or by calling the [`getPool`](../core/interfaces/IUniswapV3Factory.md#getpool) function on the `UniswapV3Factory` contract.
+You can look up the address of an existing pool on [Uniswap Info](https://app.uniswap.org/explore#/) or by calling the [`getPool`](../core/interfaces/IUniswapV3Factory.md#getpool) function on the `UniswapV3Factory` contract.
 
 ```solidity
 getPool("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", 3000)

--- a/docs/contracts/v3/reference/deployments/Celo-Deployments.md
+++ b/docs/contracts/v3/reference/deployments/Celo-Deployments.md
@@ -39,9 +39,9 @@ The `UniversalRouter` contract is the current preferred entrypoint for ERC20 and
 
 ## Uniswap Pool Deployments
 
-Every Uniswap pool is a unique instance of the `UniswapV3Pool` contract and is deployed at its own unique address. The contract source code of the pool will be auto-verified on etherscan. For example, here is the [ETH/USDC 0.3% pool](https://etherscan.io/address/0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8) on Ethereum mainnet.
+Every Uniswap pool is a unique instance of the `UniswapV3Pool` contract and is deployed at its own unique address. The contract source code of the pool will be auto-verified on the [Celo Explorer](https://celoscan.io/).
 
-You can look up the address of an existing pool on [Uniswap Info](https://info.uniswap.org/#/) or by calling the [`getPool`](../core/interfaces/IUniswapV3Factory.md#getpool) function on the `UniswapV3Factory` contract.
+You can look up the address of an existing pool on [Uniswap Info](https://app.uniswap.org/explore#/) or by calling the [`getPool`](../core/interfaces/IUniswapV3Factory.md#getpool) function on the `UniswapV3Factory` contract.
 
 ```solidity
 getPool("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", 3000)

--- a/docs/contracts/v3/reference/deployments/MegaETH-Deployments.md
+++ b/docs/contracts/v3/reference/deployments/MegaETH-Deployments.md
@@ -32,9 +32,9 @@ The `UniversalRouter` contract is the current preferred entrypoint for ERC20 and
 
 ## Uniswap Pool Deployments
 
-Every Uniswap pool is a unique instance of the `UniswapV3Pool` contract and is deployed at its own unique address. The contract source code of the pool will be auto-verified on etherscan. For example, here is the [ETH/USDC 0.3% pool](https://etherscan.io/address/0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8) on Ethereum mainnet.
+Every Uniswap pool is a unique instance of the `UniswapV3Pool` contract and is deployed at its own unique address. The contract source code of the pool will be auto-verified on the [MegaETH Explorer](https://megaeth.blockscout.com/).
 
-You can look up the address of an existing pool on [Uniswap Info](https://info.uniswap.org/#/) or by calling the [`getPool`](../core/interfaces/IUniswapV3Factory.md#getpool) function on the `UniswapV3Factory` contract.
+You can look up the address of an existing pool on [Uniswap Info](https://app.uniswap.org/explore#//) or by calling the [`getPool`](../core/interfaces/IUniswapV3Factory.md#getpool) function on the `UniswapV3Factory` contract.
 
 ```solidity
 getPool("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", 3000)

--- a/docs/contracts/v3/reference/deployments/Monad-Deployments.md
+++ b/docs/contracts/v3/reference/deployments/Monad-Deployments.md
@@ -37,9 +37,9 @@ The `UniversalRouter` contract is the current preferred entrypoint for ERC20 and
 
 ## Uniswap Pool Deployments
 
-Every Uniswap pool is a unique instance of the `UniswapV3Pool` contract and is deployed at its own unique address. The contract source code of the pool will be auto-verified on etherscan. For example, here is the [ETH/USDC 0.3% pool](https://etherscan.io/address/0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8) on Ethereum mainnet.
+Every Uniswap pool is a unique instance of the `UniswapV3Pool` contract and is deployed at its own unique address. The contract source code of the pool will be auto-verified on the [Monad Explorer](https://monadvision.com/).
 
-You can look up the address of an existing pool on [Uniswap Info](https://info.uniswap.org/#/) or by calling the [`getPool`](../core/interfaces/IUniswapV3Factory.md#getpool) function on the `UniswapV3Factory` contract.
+You can look up the address of an existing pool on [Uniswap Info](https://app.uniswap.org/explore#/) or by calling the [`getPool`](../core/interfaces/IUniswapV3Factory.md#getpool) function on the `UniswapV3Factory` contract.
 
 ```solidity
 getPool("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", 3000)

--- a/docs/contracts/v3/reference/deployments/Optimism-Deployments.md
+++ b/docs/contracts/v3/reference/deployments/Optimism-Deployments.md
@@ -41,9 +41,9 @@ The `UniversalRouter` contract is the current preferred entrypoint for ERC20 and
 
 ## Uniswap Pool Deployments
 
-Every Uniswap pool is a unique instance of the `UniswapV3Pool` contract and is deployed at its own unique address. The contract source code of the pool will be auto-verified on etherscan. For example, here is the [ETH/USDC 0.3% pool](https://etherscan.io/address/0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8) on Ethereum mainnet.
+Every Uniswap pool is a unique instance of the `UniswapV3Pool` contract and is deployed at its own unique address. The contract source code of the pool will be auto-verified on the [Optimism Explorer](https://explorer.optimism.io/).
 
-You can look up the address of an existing pool on [Uniswap Info](https://info.uniswap.org/#/) or by calling the [`getPool`](../core/interfaces/IUniswapV3Factory.md#getpool) function on the `UniswapV3Factory` contract.
+You can look up the address of an existing pool on [Uniswap Info](https://app.uniswap.org/explore#/) or by calling the [`getPool`](../core/interfaces/IUniswapV3Factory.md#getpool) function on the `UniswapV3Factory` contract.
 
 ```solidity
 getPool("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", 3000)

--- a/docs/contracts/v3/reference/deployments/Polygon-Deployments.md
+++ b/docs/contracts/v3/reference/deployments/Polygon-Deployments.md
@@ -43,9 +43,9 @@ The `UniversalRouter` contract is the current preferred entrypoint for ERC20 and
 
 ## Uniswap Pool Deployments
 
-Every Uniswap pool is a unique instance of the `UniswapV3Pool` contract and is deployed at its own unique address. The contract source code of the pool will be auto-verified on etherscan. For example, here is the [ETH/USDC 0.3% pool](https://etherscan.io/address/0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8) on Ethereum mainnet.
+Every Uniswap pool is a unique instance of the `UniswapV3Pool` contract and is deployed at its own unique address. The contract source code of the pool will be auto-verified on the [PolygonScan](https://polygonscan.com/).
 
-You can look up the address of an existing pool on [Uniswap Info](https://info.uniswap.org/#/) or by calling the [`getPool`](../core/interfaces/IUniswapV3Factory.md#getpool) function on the `UniswapV3Factory` contract.
+You can look up the address of an existing pool on [Uniswap Info](https://app.uniswap.org/explore#/) or by calling the [`getPool`](../core/interfaces/IUniswapV3Factory.md#getpool) function on the `UniswapV3Factory` contract.
 
 ```solidity
 getPool("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", 3000)

--- a/docs/contracts/v3/reference/deployments/Tempo-Deployments.md
+++ b/docs/contracts/v3/reference/deployments/Tempo-Deployments.md
@@ -16,7 +16,7 @@ The latest version of `@uniswap/v3-core`, `@uniswap/v3-periphery`, and `@uniswap
 | [Quoter](https://github.com/Uniswap/uniswap-v3-periphery/blob/v1.0.0/contracts/lens/Quoter.sol)                                                              | `0x9a0dd5fda50d8df9dd6fa4b4be33b6b1e241b408` |
 | [SwapRouter](https://github.com/Uniswap/swap-router-contracts)                                                                                              | `0x6a3988d2366ad79917a2399f18a1a82b157470e1` |
 | [SwapRouter02](https://github.com/Uniswap/swap-router-contracts/blob/main/contracts/SwapRouter02.sol)                                                      | `0x7e9d53081e961201837336bcd81f52ae92691a8f` |
-| [Permit2](https://github.com/Uniswap/permit2)                                                                                                                | `0x000000000022D473030F116dDEE9F6B43aC78BA3` |
+| [Permit2](https://github.com/Uniswap/permit2)                                                                                                                | `0x000000000022d473030f116ddee9f6b43ac78ba3` |
 | [UniversalRouter](https://github.com/Uniswap/universal-router)                                                                                              | `0xa2dc7d0266f0cc50b3eeaf36c9bfcecff1beea91` |
 
 These addresses are final and were deployed from these npm package versions:
@@ -32,9 +32,9 @@ The `UniversalRouter` contract is the current preferred entrypoint for ERC20 and
 
 ## Uniswap Pool Deployments
 
-Every Uniswap pool is a unique instance of the `UniswapV3Pool` contract and is deployed at its own unique address. The contract source code of the pool will be auto-verified on etherscan. For example, here is the [ETH/USDC 0.3% pool](https://etherscan.io/address/0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8) on Ethereum mainnet.
+Every Uniswap pool is a unique instance of the `UniswapV3Pool` contract and is deployed at its own unique address. The contract source code of the pool will be auto-verified on the [Tempo Explorer](https://explore.tempo.xyz/).
 
-You can look up the address of an existing pool on [Uniswap Info](https://info.uniswap.org/#/) or by calling the [`getPool`](../core/interfaces/IUniswapV3Factory.md#getpool) function on the `UniswapV3Factory` contract.
+You can look up the address of an existing pool on [Uniswap Info](https://app.uniswap.org/explore#/) or by calling the [`getPool`](../core/interfaces/IUniswapV3Factory.md#getpool) function on the `UniswapV3Factory` contract.
 
 ```solidity
 getPool("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", 3000)

--- a/docs/contracts/v3/reference/deployments/Unichain-Deployments.md
+++ b/docs/contracts/v3/reference/deployments/Unichain-Deployments.md
@@ -34,9 +34,9 @@ The `UniversalRouter` contract is the current preferred entrypoint for ERC20 and
 
 ## Uniswap Pool Deployments
 
-Every Uniswap pool is a unique instance of the `UniswapV3Pool` contract and is deployed at its own unique address. The contract source code of the pool will be auto-verified on etherscan. For example, here is the [ETH/USDC 0.3% pool](https://etherscan.io/address/0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8) on Ethereum mainnet.
+Every Uniswap pool is a unique instance of the `UniswapV3Pool` contract and is deployed at its own unique address. The contract source code of the pool will be auto-verified on [Uniscan](https://uniscan.xyz/).
 
-You can look up the address of an existing pool on [Uniswap Info](https://info.uniswap.org/#/) or by calling the [`getPool`](../reference/core/interfaces/IUniswapV3Factory.md#getpool) function on the `UniswapV3Factory` contract.
+You can look up the address of an existing pool on [Uniswap Info](https://app.uniswap.org/explore#/) or by calling the [`getPool`](../reference/core/interfaces/IUniswapV3Factory.md#getpool) function on the `UniswapV3Factory` contract.
 
 ```solidity
 getPool("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", 3000)

--- a/docs/contracts/v3/reference/deployments/WorldChain-Deployments.md
+++ b/docs/contracts/v3/reference/deployments/WorldChain-Deployments.md
@@ -35,9 +35,9 @@ The `UniversalRouter` contract is the current preferred entrypoint for ERC20 and
 
 ## Uniswap Pool Deployments
 
-Every Uniswap pool is a unique instance of the `UniswapV3Pool` contract and is deployed at its own unique address. The contract source code of the pool will be auto-verified on etherscan. For example, here is the [ETH/USDC 0.3% pool](https://etherscan.io/address/0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8) on Ethereum mainnet.
+Every Uniswap pool is a unique instance of the `UniswapV3Pool` contract and is deployed at its own unique address. The contract source code of the pool will be auto-verified on the [WorldChain Explorer](https://worldscan.org/).
 
-You can look up the address of an existing pool on [Uniswap Info](https://info.uniswap.org/#/) or by calling the [`getPool`](../reference/core/interfaces/IUniswapV3Factory.md#getpool) function on the `UniswapV3Factory` contract.
+You can look up the address of an existing pool on [Uniswap Info](https://app.uniswap.org/explore#/) or by calling the [`getPool`](../reference/core/interfaces/IUniswapV3Factory.md#getpool) function on the `UniswapV3Factory` contract.
 
 ```solidity
 getPool("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", 3000)

--- a/docs/contracts/v3/reference/deployments/ZKsync-Deployments.md
+++ b/docs/contracts/v3/reference/deployments/ZKsync-Deployments.md
@@ -38,9 +38,9 @@ The `UniversalRouter` contract is the current preferred entrypoint for ERC20 and
 
 ## Uniswap Pool Deployments
 
-Every Uniswap pool is a unique instance of the `UniswapV3Pool` contract and is deployed at its own unique address. The contract source code of the pool will be auto-verified on etherscan. For example, here is the [ETH/USDC 0.3% pool](https://etherscan.io/address/0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8) on Ethereum mainnet.
+Every Uniswap pool is a unique instance of the `UniswapV3Pool` contract and is deployed at its own unique address. The contract source code of the pool will be auto-verified on the [ZKsync Explorer](https://explorer.zksync.io/).
 
-You can look up the address of an existing pool on [Uniswap Info](https://app.uniswap.org/explore) or by calling the [`getPool`](../core/interfaces/IUniswapV3Factory.md#getpool) function on the `UniswapV3Factory` contract.
+You can look up the address of an existing pool on [Uniswap Info](https://app.uniswap.org/explore#/) or by calling the [`getPool`](../core/interfaces/IUniswapV3Factory.md#getpool) function on the `UniswapV3Factory` contract.
 
 ```solidity
 getPool("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", 3000)

--- a/docs/contracts/v3/reference/deployments/Zora-Deployments.md
+++ b/docs/contracts/v3/reference/deployments/Zora-Deployments.md
@@ -36,9 +36,9 @@ The `UniversalRouter` contract is the current preferred entrypoint for ERC20 and
 
 ## Uniswap Pool Deployments
 
-Every Uniswap pool is a unique instance of the `UniswapV3Pool` contract and is deployed at its own unique address. The contract source code of the pool will be auto-verified on etherscan. For example, here is the [ETH/USDC 0.3% pool](https://etherscan.io/address/0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8) on Ethereum mainnet.
+Every Uniswap pool is a unique instance of the `UniswapV3Pool` contract and is deployed at its own unique address. The contract source code of the pool will be auto-verified on the [Zora Explorer](https://explorer.zora.energy/).
 
-You can look up the address of an existing pool on [Uniswap Info](https://info.uniswap.org/#/) or by calling the [`getPool`](../core/interfaces/IUniswapV3Factory.md#getpool) function on the `UniswapV3Factory` contract.
+You can look up the address of an existing pool on [Uniswap Info](https://app.uniswap.org/explore#) or by calling the [`getPool`](../core/interfaces/IUniswapV3Factory.md#getpool) function on the `UniswapV3Factory` contract.
 
 ```solidity
 getPool("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", 3000)


### PR DESCRIPTION
## Summary

- Standardized the **Uniswap Pool Deployments** copy across v3 deployment pages for chain consistency.
- Removed Ethereum-specific wording/examples from chain-specific pages.
- Updated explorer references to be chain-appropriate and explicit (e.g. Arbitrum Explorer, Tempo Explorer, PolygonScan, etc).
- Aligned Tempo table formatting updates for consistency with the rest of its deployment entries.