### PR TITLE
add docusaurus-plugin-copy-page-button

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -154,6 +154,7 @@ const config: Config = {
   ],
   plugins: [
     tailwindPlugin,
+    'docusaurus-plugin-copy-page-button',
     ['@saucelabs/theme-github-codeblock', {}],
     [
       '@docusaurus/plugin-client-redirects',

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "caniuse-lite": "^1.0.30001519",
     "classnames": "^2.5.1",
     "clsx": "^1.1.1",
-    "docusaurus-plugin-copy-page-button": "^0.5.1",
+    "docusaurus-plugin-copy-page-button": "^0.8.0",
     "docusaurus-plugin-llms": "^0.2.0",
     "hast-util-is-element": "1.1.0",
     "intl-locales-supported": "^1.8.12",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "caniuse-lite": "^1.0.30001519",
     "classnames": "^2.5.1",
     "clsx": "^1.1.1",
+    "docusaurus-plugin-copy-page-button": "^0.5.1",
     "docusaurus-plugin-llms": "^0.2.0",
     "hast-util-is-element": "1.1.0",
     "intl-locales-supported": "^1.8.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5029,6 +5029,11 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+docusaurus-plugin-copy-page-button@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/docusaurus-plugin-copy-page-button/-/docusaurus-plugin-copy-page-button-0.8.0.tgz#31b24ad7e8de434ca1dfd2d8c08ba4024d0a96aa"
+  integrity sha512-WsdA9yDlOevHuKiHMq/aZJvLViyYmlyYEPtYaIvL09qScZLu27Lyx7ABycgYz10t389nnz7NcfSKD3ghMs62fg==
+
 docusaurus-plugin-llms@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/docusaurus-plugin-llms/-/docusaurus-plugin-llms-0.2.2.tgz#3461e8295d18d4057cf0fbcf5e3feac561ea6fd1"
@@ -10682,7 +10687,16 @@ stop-iteration-iterator@^1.1.0:
     es-errors "^1.3.0"
     internal-slot "^1.1.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -10790,7 +10804,14 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -11772,7 +11793,16 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
adds docusaurus-plugin-copy-page-button — a "Copy page" button in the docs sidebar that exports the current page as clean markdown, with one-click "Open in ChatGPT / Claude / Gemini" actions.

useful for the contracts/SDK pages especially — when someone's on, say, a v4 hooks page or a SwapRouter reference and wants to ask claude "rewrite this for my use case", they can grab the page markdown in one click rather than copy/pasting around the page chrome.

complementary to docusaurus-plugin-llms that's already in here — llms.txt covers full-site discovery for AI tools, this covers per-page handoff for a human reader who wants to drop a single page into a chat. theme-aware, mobile friendly, auto-injects into the TOC sidebar, no config required.

already running on Arbitrum docs (similar docusaurus + ai-tooling setup) and ~12 other sites including Ethereum execution-apis, Sui, Monad, Flare, Kaia, Cardano. listed in Docusaurus community plugins.

repo: https://github.com/portdeveloper/docusaurus-plugin-copy-page-button
npm: https://www.npmjs.com/package/docusaurus-plugin-copy-page-button
demo: https://portdeveloper.github.io/copy-page-button-showcase/

happy to adjust or close if not a fit