### PR TITLE
docs: install universal router from main for v4 swaps

### DIFF
--- a/docs/contracts/v4/quickstart/swap.mdx
+++ b/docs/contracts/v4/quickstart/swap.mdx
@@ -15,7 +15,7 @@ Set up a foundry project and install the necessary dependencies:
 forge install uniswap/v4-core
 forge install uniswap/v4-periphery
 forge install uniswap/permit2
-forge install uniswap/universal-router
+forge install uniswap/universal-router@main
 forge install uniswap/v3-core
 forge install uniswap/v2-core
 forge install OpenZeppelin/openzeppelin-contracts


### PR DESCRIPTION
## Summary
- updates the v4 Swap quickstart to install `uniswap/universal-router@main`
- ensures the installed Universal Router source includes the `V4_SWAP` command used later in the guide

Closes Uniswap/universal-router#484

## Test Plan
- `npx --yes prettier@3.3.3 --check docs/contracts/v4/quickstart/swap.mdx`
- `git diff --check`
