### PR TITLE
docs(unichain/tools/node-providers): add third-party benchmark comparison

### DIFF
--- a/content/unichain/tools/node-providers.mdx
+++ b/content/unichain/tools/node-providers.mdx
@@ -87,3 +87,7 @@ Get started [here](https://documentation.onfinality.io/support/getting-started)
 ### Supported networks
 - [Unichain Mainnet](https://onfinality.io/networks/unichain)
 - [Unichain Sepolia Testnet](https://onfinality.io/networks/unichain-sepolia)
+
+## Compare provider performance
+
+For an independent third-party comparison of the Unichain RPC providers listed above, see the [OpenChainBench Unichain RPC benchmark](https://openchainbench.com/benchmarks/unichain-rpc). Latency (p50/p95/p99), reliability, and stale-block detection are probed every minute from three regions (US East, EU West, Singapore) and published alongside the open-source harness under a CC BY 4.0 data license.


### PR DESCRIPTION
## Summary

Adds a short `Compare provider performance` subsection at the end of `content/unichain/tools/node-providers.mdx`, pointing readers to the [OpenChainBench Unichain RPC benchmark](https://openchainbench.com/benchmarks/unichain-rpc) as a neutral third-party latency comparison of the Unichain node providers listed on the same page.

## Why it fits

The page already directs Unichain builders to eight node providers (Alchemy, Blockdaemon, Chainstack, dRPC, Dwellir, Infura, QuickNode, OnFinality) plus the public Unichain endpoint. Each provider publishes its own performance claims. What is missing is a way to compare them side by side against the same request pattern. OpenChainBench probes the Unichain endpoints every minute from three regions (US East, EU West, Singapore) and publishes p50/p95/p99 latency, reliability classification, and stale-block detection under a CC BY 4.0 data license alongside the open-source Go harness. OpenChainBench has no affiliation with any of the listed providers or the Uniswap Foundation, so its ranking is neutral by construction.

## Change

One added subsection at the end of the file, after the existing OnFinality entry. No changes to any other provider entry.

## Disclosure

I am the maintainer of OpenChainBench. Happy to reword, shorten, or drop the reference entirely if it does not fit the docs style guide.