### PR TITLE
Note the per-tick liquidityGross cap on full-range positions

### DIFF
--- a/content/sdks/v4/guides/managing-liquidity/position-minting.mdx
+++ b/content/sdks/v4/guides/managing-liquidity/position-minting.mdx
@@ -136,6 +136,7 @@ let tickUpper: number
 
 if (fullRange) {
   // For full-range positions, use Uniswap's minimum and maximum allowed ticks
+  // See the note below before hardcoding these bounds in a contract
   const MIN_TICK = -887272
   const MAX_TICK = 887272
 
@@ -162,6 +163,12 @@ const amountBDesired = BigInt(Math.floor(amountB * 10 ** USDC_TOKEN.decimals))
 const amount0Desired = token0IsA ? amountADesired.toString() : amountBDesired.toString()
 const amount1Desired = token0IsA ? amountBDesired.toString() : amountADesired.toString()
 ```
+
+> Each tick has a `liquidityGross` counter capped at `maxLiquidityPerTick`. The cap bounds per-tick liquidity so that a pool's active liquidity cannot overflow when a tick is crossed. It is shared by every position that uses the tick as a bound, first come first served.
+>
+> At the minimum and maximum usable ticks the price range spanned by one tick spacing is very small, so filling the cap there costs very little. Anyone can do it. Once a tick is at its cap, any mint or increase using that exact tick reverts with `TickLiquidityOverflow`. If you hit this, move the affected bound in by one or two tick spacings. On a pool with tick spacing 10 the extreme bounds sit at prices around 1e38 and 1e-39, so shifting in by a spacing or two leaves the position covering the same trading range in practice and requires the same capital.
+>
+> Contracts that hardcode their tick bounds and cannot change them later should not use the extreme ticks. Choose bounds where filling `maxLiquidityPerTick` would require more tokens than the pair's supply. Uniswap's [`InstantLaunchStrategy`](https://github.com/Uniswap/liquidity-launcher/blob/main/src/strategies/InstantLaunchStrategy.sol) does this with its `MIN_LAUNCH_TICK` and `MAX_INITIAL_TICK` values.
 
 ### Step 5: Create a position
 


### PR DESCRIPTION
Adds a note to the v4 position minting guide about the per-tick `liquidityGross` cap.

The guide currently shows `nearestUsableTick(MIN_TICK/MAX_TICK, tickSpacing)` as the way to build a full-range position, with no mention that those ticks share a `maxLiquidityPerTick` budget that anyone can fill for a very small amount of tokens. Once a tick is at its cap, mints and increases using that exact tick revert with `TickLiquidityOverflow`.

This came out of a public bug bounty submission on Cantina (#909). The submission was rejected, the cap is a safety parameter and reaching it is the intended tradeoff, but the researcher has audited several integrations that hardcode the extreme ticks in immutable code and cannot move their bounds. The note reflects the rejection reasoning: shift the bound in by a spacing or two, and do not hardcode the extreme ticks in a contract.

The note covers three things:

1. What the cap is and why it exists.
2. What to do if you hit it as a user, and why shifting the bound costs nothing in practice.
3. What contracts with fixed bounds should do instead, pointing at `InstantLaunchStrategy` as the example.
