### PR TITLE
fix(liquidity-launchpad): update CCA factory API to v2.x

### DIFF
--- a/content/liquidity/liquidity-launchpad/deployments.mdx
+++ b/content/liquidity/liquidity-launchpad/deployments.mdx
@@ -6,7 +6,7 @@ description: Find Uniswap Liquidity Launchpad, CCA, and strategy contract deploy
 View the changelogs for more details on differences between contract deployments: [continuous-clearing-auction](https://github.com/Uniswap/continuous-clearing-auction/blob/main/CHANGELOG.md) and [liquidity-launcher](https://github.com/Uniswap/liquidity-launcher/blob/main/CHANGELOG.md).
 
 ## ContinuousClearingAuctionFactory
-The CCA factory has no constructor parameters so it can be deployed to the same address across all compatible chains. v2.0.0 is deployed on all currently supported chains.
+The CCA factory constructor takes a single `address _protocolFeeController` argument. The canonical deployments all pass the same value, so they share one address across every compatible chain. Deploy a new factory to use a different fee controller.
 
 | Address                                    | Commit Hash                              | Version           |
 | ------------------------------------------ | ---------------------------------------- | ----------------- |

--- a/content/liquidity/liquidity-launchpad/guides/example-configuration.mdx
+++ b/content/liquidity/liquidity-launchpad/guides/example-configuration.mdx
@@ -124,7 +124,8 @@ Now let's finish the script:
         address deployer = vm.envAddress("DEPLOYER");
 
         vm.startBroadcast();
-        ContinuousClearingAuctionFactory factory = new ContinuousClearingAuctionFactory();
+        // Pass address(0) to run without a protocol fee controller.
+        ContinuousClearingAuctionFactory factory = new ContinuousClearingAuctionFactory(address(0));
         console2.log("Factory deployed to:", address(factory));
 
         ERC20Mock token = new ERC20Mock();
@@ -146,7 +147,7 @@ Now let's finish the script:
             auctionStepsData: auctionStepsData
         });
 
-        IDistributionContract auction = IDistributionContract(factory.initializeDistribution(address(token), totalSupply, abi.encode(parameters), bytes32(0)));
+        IDistributor auction = factory.create(address(token), totalSupply, abi.encode(parameters), bytes32(0));
         token.mint(address(auction), totalSupply);
         console2.log("Auction deployed to:", address(auction));
 
@@ -172,7 +173,7 @@ pragma solidity ^0.8.0;
 import {Script} from "forge-std/Script.sol";
 import {ContinuousClearingAuctionFactory} from "../src/ContinuousClearingAuctionFactory.sol";
 import {AuctionParameters} from "../src/interfaces/IContinuousClearingAuction.sol";
-import {IDistributionContract} from "../src/interfaces/external/IDistributionContract.sol";
+import {IDistributor} from "liquidity-launcher/src/interfaces/IDistributor.sol";
 import {AuctionStepsBuilder} from "../test/utils/AuctionStepsBuilder.sol";
 import {ERC20Mock} from '@openzeppelin/contracts/mocks/token/ERC20Mock.sol';
 import {console2} from "forge-std/console2.sol";
@@ -185,7 +186,8 @@ contract ExampleCCADeploymentScript is Script {
         address deployer = vm.envAddress("DEPLOYER");
 
         vm.startBroadcast();
-        ContinuousClearingAuctionFactory factory = new ContinuousClearingAuctionFactory();
+        // Pass address(0) to run without a protocol fee controller.
+        ContinuousClearingAuctionFactory factory = new ContinuousClearingAuctionFactory(address(0));
         console2.log("Factory deployed to:", address(factory));
 
         ERC20Mock token = new ERC20Mock();
@@ -207,7 +209,7 @@ contract ExampleCCADeploymentScript is Script {
             auctionStepsData: auctionStepsData
         });
 
-        IDistributionContract auction = IDistributionContract(factory.initializeDistribution(address(token), totalSupply, abi.encode(parameters), bytes32(0)));
+        IDistributor auction = factory.create(address(token), totalSupply, abi.encode(parameters), bytes32(0));
 
         token.mint(address(auction), totalSupply);
         auction.onTokensReceived();

--- a/content/liquidity/liquidity-launchpad/guides/local-deployment.mdx
+++ b/content/liquidity/liquidity-launchpad/guides/local-deployment.mdx
@@ -18,23 +18,26 @@ There are two main ways to deploy new CCA auctions:
 2. Deploying a new `ContinuousClearingAuction` contract directly
 
 ### Deploying via factory (recommended)
-The `ContinuousClearingAuctionFactory` contract is a factory contract that deploys new instances of the contract. It inherits the `IDistributionStrategy` interface from the [Liquidity Launcher](https://github.com/Uniswap/liquidity-launcher) contracts.
+The `ContinuousClearingAuctionFactory` contract is a factory contract that deploys new instances of the contract. It implements the `IDistributorFactory` interface from the [Liquidity Launcher](https://github.com/Uniswap/liquidity-launcher) contracts.
 
 ```solidity
-interface IDistributionStrategy {
-    /// @notice Initialize a distribution of tokens under this strategy.
-    /// @dev Contracts can choose to deploy an instance with a factory-model or handle all distributions within the
-    /// implementing contract. For some strategies this function will handle the entire distribution, for others it
-    /// could merely set up initial state and provide additional entrypoints to handle the distribution logic.
-    /// @param token The token that is being distributed.
-    /// @param totalSupply The supply of the token that is being distributed.
-    /// @param configData Arbitrary, strategy-specific parameters.
-    /// @param salt The optional salt for deterministic deployment.
-    /// @return distributionContract The contract that will handle or manage the distribution.
-    ///         (Could be `address(this)` if the strategy is handled in-place, or a newly deployed instance).
-    function initializeDistribution(address token, uint256 totalSupply, bytes calldata configData, bytes32 salt)
+interface IDistributorFactory {
+    /// @notice Creates a distributor without funding it.
+    /// @param token The token that will be distributed.
+    /// @param totalSupply The supply of the token that will be distributed.
+    /// @param configData Arbitrary, factory-specific parameters.
+    /// @param salt The salt for deterministic deployment, if used by the factory.
+    /// @return distributor The contract that will handle or manage the distribution.
+    function create(address token, uint256 totalSupply, bytes calldata configData, bytes32 salt)
         external
-        returns (IDistributionContract distributionContract);
+        returns (IDistributor distributor);
+
+    /// @notice Returns the distributor address for the provided creation parameters.
+    /// @param sender The address that would call {create}.
+    function getAddress(address token, uint256 totalSupply, bytes calldata configData, bytes32 salt, address sender)
+        external
+        view
+        returns (IDistributor distributor);
 }
 ```
 
@@ -50,7 +53,7 @@ The factory contract is deployed to the same address across the following networ
 CCA auctions can be deployed directly by calling the constructor:
 
 ```solidity
-constructor(address _token, uint128 _totalSupply, AuctionParameters memory _parameters)
+constructor(address _token, uint128 _totalSupply, AuctionParameters memory _parameters, address _protocolFeeController)
 
 /// from: https://github.com/Uniswap/continuous-clearing-auction/blob/main/src/interfaces/IContinuousClearingAuction.sol
 struct AuctionParameters {
@@ -71,9 +74,9 @@ struct AuctionParameters {
 We'll be using the factory method for the rest of this guide.
 
 ## Step 2: Understand Factory Entrypoints
-The factory contract has two functions: `initializeDistribution()` and `getAuctionAddress()`. It has no constructor parameters so it can be easily deployed to the same address across all networks.
+The factory contract has two entrypoints: `create()` and `getAddress()`. Its constructor takes a single `address _protocolFeeController` argument, which is stored as an immutable and applied to every auction the factory creates. Deploy a new factory to use a different fee controller.
 
-### initializeDistribution()
+### create()
 This is the main entrypoint and is called by integrating contracts within the `LiquidityLauncher` system.
 
 It performs basic validation checks:
@@ -93,8 +96,8 @@ Finally, an optional caller provided `salt` is hashed with the auction parameter
 
 This function emits the `AuctionCreated` event with address of the new auction contract as well as the `amount` and `token` being distributed.
 
-### getAuctionAddress()
-This function is a simple view function that performs the same logic as `initializeDistribution()` but does not deploy a new contract. It calculates and returns the address of the new auction contract.
+### getAddress()
+This function is a simple view function that performs the same logic as `create()` but does not deploy a new contract. It calculates and returns the address of the new auction contract.
 
 Onchain integrators will find this function useful for calculating the address of an auction contract before it is deployed.
 
@@ -107,7 +110,7 @@ pragma solidity ^0.8.0;
 
 import {Script} from "forge-std/Script.sol";
 import {ContinuousClearingAuctionFactory} from "../src/ContinuousClearingAuctionFactory.sol";
-import {IDistributionContract} from "../src/interfaces/external/IDistributionContract.sol";
+import {IDistributor} from "liquidity-launcher/src/interfaces/IDistributor.sol";
 import {console2} from "forge-std/console2.sol";
 
 contract ExampleCCADeploymentScript is Script {
@@ -115,10 +118,11 @@ contract ExampleCCADeploymentScript is Script {
 
     function run() public {
         vm.startBroadcast();
-        ContinuousClearingAuctionFactory factory = new ContinuousClearingAuctionFactory();
+        // Pass address(0) to run without a protocol fee controller.
+        ContinuousClearingAuctionFactory factory = new ContinuousClearingAuctionFactory(address(0));
         console2.log("Factory deployed to:", address(factory));
 
-        // TODO: configure the auction and deploy it via `initializeDistribution()`
+        // TODO: configure the auction and deploy it via `create()`
 
         vm.stopBroadcast();
     }


### PR DESCRIPTION
### Summary

The CCA guides still document the v1 factory API, so the sample scripts don't compile against the deployed contracts. v2.0.0 renamed the entrypoints and added a fee controller argument to the constructors.

Affected pages:
- [Deployments](https://developers.uniswap.org/docs/liquidity/liquidity-launchpad/deployments)
- [Create a Local Deployment](https://developers.uniswap.org/docs/liquidity/liquidity-launchpad/guides/local-deployment)
- [Example Configuration](https://developers.uniswap.org/docs/liquidity/liquidity-launchpad/guides/example-configuration)

What the guides say vs. what v2.x has:
- `initializeDistribution()` ‚Üí `create()`
- `getAuctionAddress()` ‚Üí `getAddress()`
- `IDistributionStrategy` / `IDistributionContract` ‚Üí `IDistributorFactory` / `IDistributor`, from `liquidity-launcher`
- `new ContinuousClearingAuctionFactory()` ‚Üí constructor takes `address _protocolFeeController`
- auction `constructor(address, uint128, AuctionParameters)` ‚Üí takes a fourth `address _protocolFeeController`

Both changes are in the v2.0.0 changelog: #356 for the renames, #340 for the fee controller.

The Deployments page also says the factory "has no constructor parameters". It takes one ‚Äî the canonical deployments land on the same address because they all pass the same value, not because the constructor is empty.

### Type of change

- [x] Fix (typo, broken link, incorrect or outdated content)
- [ ] New content (guide, page, code example)
- [ ] Update to existing content
- [ ] Other

### How has this been verified?

I checked the deployed v2.1.0 factory at `0x000000001F26a0044BaA66024e7b6599c61963F8`. Its runtime bytecode contains the selectors for `create()` (`0x4aaa5b37`), `getAddress()` (`0x1bfb751b`) and `protocolFeeController()` (`0xf02de3b2`), and does not contain `0x03770504` (`initializeDistribution`) or `0xbad1bd50` (`getAuctionAddress`) ‚Äî so the documented calls would revert.

`eth_getCode` returns identical bytecode on Ethereum, Unichain, Base, Arbitrum and Avalanche (codehash `0xa1d2a90564f4f63580b25de42efaff92505c254b00fc666f65ab38126cce5cfa`). `protocolFeeController()` returns the zero address on both Ethereum and Avalanche, which is why one address still works everywhere.

For the snippets: the import paths I used are already remapped in the CCA repo's `foundry.toml` (`liquidity-launcher=lib/liquidity-launcher`), and `onTokensReceived()`, used later in the example configuration, is declared on `IDistributor`.

### Anything else reviewers should know?

Two related things I ran into but didn't touch here, since they don't live in this repo's content:

1. The Deployments page lists the factory on Ethereum, Unichain, Base, Arbitrum, Robinhood Chain and Sepolia. The same address also has code on Avalanche (43114), X Layer (196) and Ink (57073), and `deployments.json` has no factory record for those three ‚Äî although it does list `LiquidityLauncher`, `LBPStrategy` and `TokenSplitter` on Avalanche.
2. `CCALens` and `TickDataLens` (added in #325) aren't on the Deployments page or in `deployments.json` on any chain.

Happy to open a separate issue for those if that's easier to track.
