### PR TITLE
docs: document trade-type constraints for hooked pools

### DIFF
--- a/content/protocols/v4/concepts/hook-routing.mdx
+++ b/content/protocols/v4/concepts/hook-routing.mdx
@@ -21,3 +21,23 @@ If you have built a hook that you would like to have allowlisted, fill out the [
 
 You can review current allowlisted hooks in [Allowlisted Hooks](https://support.uniswap.org/hc/en-us/articles/41305283155597-Allowlisted-Hooks).
 
+## Allowlisting and swap compatibility
+
+Allowlisting makes hooked pools eligible for routing. It does not change a hook's validation rules or guarantee that a pool can satisfy every quote request.
+
+A hook can accept or reject swaps based on the swap direction, trade type, pool, caller, hook data, or current state. For each pool and relevant hook state, test all four direction and trade-type combinations:
+
+| Direction | `EXACT_INPUT` | `EXACT_OUTPUT` |
+| --- | --- | --- |
+| `currency0` to `currency1` | Test | Test |
+| `currency1` to `currency0` | Test | Test |
+
+If the pool is intended for multi-hop routing, test the supported combinations in every applicable path position.
+
+If any combination is unsupported, document the constraint for integrators. If an integration submits a pay-side amount as `EXACT_INPUT`, that request may not return a pool whose hook accepts only `EXACT_OUTPUT` in that direction.
+
+<Callout title="Input budgets for exact-output-only directions" type="info">
+  If the hook guarantees that, for a fixed state, required input is monotonic with requested output over a known range, an integrator can translate an input budget with a bounded search over exact-output quotes. Revalidate the result before execution and use maximum-input protection. Otherwise, require the user to specify the desired output or use hook-specific integration logic.
+</Callout>
+
+See [Getting a Quote](/docs/sdks/v4/guides/swapping/quoting) for v4 exact-input and exact-output quote methods and [Swap Routing](/docs/trading/swapping-api/concepts/swap-routing) for API routing behavior.

--- a/content/trading/swapping-api/concepts/swap-routing.mdx
+++ b/content/trading/swapping-api/concepts/swap-routing.mdx
@@ -4,12 +4,19 @@ description: 'Use Uniswap API routing fields to choose protocol paths and return
 icon: 'route'
 ---
 ## Routing Principles
-In order to get the appropriate swap routing, it is important to closely consider the values submitted through the `/quote` `protocols` and `routingPreference` fields. We recommend specifying the desired swap routing by specifying all `protocols` which you feel comfortable using and leaving the `routingPreference` field blank.
+In order to get the appropriate swap routing, it is important to closely consider the values submitted through the `/quote` `type`, `protocols`, and `routingPreference` fields. We recommend specifying the desired swap routing by specifying all `protocols` which you feel comfortable using and leaving the `routingPreference` field blank.
 
+- For a Uniswap Protocol AMM swap, the `type` field determines which side is fixed. `EXACT_INPUT` fixes the amount sent and quotes a variable output. `EXACT_OUTPUT` fixes the amount received and quotes a variable input. See [Chained Actions](/docs/trading/swapping-api/chained-actions) for multi-step routes with additional exact-input behavior.
 - The `protocols` field is used to specify the protocols from which pricing will be considered and through which your swap may eventually be executed. The possible values for the field are `V2`, `V3`, `V4`, `UNISWAPX_V2`, and `UNISWAPX_V3`
 - The `routingPreference` field is used to specify the preferred matching strategy. The possible values for the field are `BEST_PRICE` and `FASTEST`
 
 For complete information on the available values and combinations for the `protocols` and `routingPreference` fields, see [Swapping Architecture Overview](/docs/trading/swapping-api/getting-started). A summary is provided below:
+
+<Callout title="Trade type is part of the routing request" type="info">
+  For Uniswap Protocol AMM routing, exact input and exact output are separate quote requests. `BEST_PRICE` optimizes routes for the submitted `type`; it does not reinterpret `EXACT_INPUT` as `EXACT_OUTPUT`.
+
+  This distinction is especially important for v4 hooks with custom swap validation. If a hooked pool accepts a direction only as exact output, an exact-input request for that direction may not return the pool even when the pool can satisfy a separately formulated exact-output request. Supporting the input-budget intent requires hook-specific translation logic or an explicitly requested output amount. See [Integrated Routing with UniswapX](/docs/protocols/v4/concepts/hook-routing#allowlisting-and-swap-compatibility).
+</Callout>
 
 ## Routing Outcomes
 


### PR DESCRIPTION
### Summary

This PR documents a routing constraint for non-vanilla v4 hooks: allowlisting makes a hooked pool eligible for routing, but it does not change the hook's swap validation or make the pool compatible with every direction and trade type.

The update:

- adds a four-quadrant compatibility checklist for both directions and `EXACT_INPUT`/`EXACT_OUTPUT`;
- tells hook builders to test and document direction-, state-, and trade-type-specific constraints;
- scopes `BEST_PRICE` to the submitted trade type for Uniswap Protocol AMM routing; and
- explains that an input-budget experience for an exact-output-only direction needs hook-specific intent translation or an explicitly requested output amount.

This is a generic documentation change. It does not add Morphogen-specific content to the published docs and does not change routing behavior.

### Why this is needed

The current hook-routing page explains allowlisting, but not that an allowlisted hook can still reject a quote because of its direction, trade type, or current state. The Swap Routing page explains `protocols` and `routingPreference`, but does not currently explain how `type` constrains Uniswap Protocol AMM routing.

A verified production case makes the missing guidance concrete:

| User formulation | Interface trade type | Canonical Morphogen buy behavior |
| --- | --- | --- |
| Enter ETH on the pay side | `EXACT_INPUT` | Rejected by the hook with `BuyRequiresExactOutput` |
| Enter the desired MGEN output | `EXACT_OUTPUT` | Accepted by the canonical hook |

The Morphogen hook is source-verified, marked `vanillaSwap: false`, and publicly allowlisted on Robinhood Chain. Its verified source requires MGEN buys to use exact output and MGEN sells to use exact input in both formation and permanent phases. `EXACT_OUTPUT` is a first-class v4 quote and execution mode, but it is a separate request type. The canonical quoter and router expose the corresponding exact-output purchase path, and a successful production transaction exercises that path with a declared maximum input and a nonzero refund.

Uniswap's public Interface derives `tradeType` from the edited field and preserves it in the quote request. In the public UniRoute request-to-execution path reviewed for this change, `tradeType` is likewise preserved through quote processing, route selection, and trade construction.

The hook registry can identify Morphogen as non-vanilla, but its current schema has no direction-specific `EXACT_INPUT`/`EXACT_OUTPUT` capability fields. Allowlisting therefore makes the pool eligible for routing without expressing this constraint in a standard machine-readable form.

This PR does not claim that the public UniRoute repository is byte-for-byte identical to every production service. It documents the integration constraint demonstrated by Uniswap's public API definitions, interface source, routing source, hook registry, and the verified deployed hook.

<details>
<summary>Canonical production identifiers</summary>

- Chain: Robinhood Chain (`4663`)
- MGEN: `0x822850e3d25A19258eE160F8Bb33FB1345B70372`
- Hook: `0xD27596adD474e5f645Cc1D2141e8Ff2A3FD33AEC`
- Pool ID: `0xae0acc3836678141dc58ac679d2ab66619afedf32095fde8f773aead524847ca`
- Reference router: `0xFCB9b9dC8DDCaA1a71869Bf0003d6da493C8BABb`
- Reference quoter: `0x5f586aBcED4982a88426034CD1c0Fa72F59b5756`
- Canonical market: [Dexscreener](https://dexscreener.com/robinhood/0xae0acc3836678141dc58ac679d2ab66619afedf32095fde8f773aead524847ca)

The linked production transaction requested `110,651.713076158913831201 MGEN`, declared a maximum input of `1.009999999964863360 ETH`, spent `0.999999999965211247 ETH`, refunded `0.009999999999652113 ETH`, and succeeded onchain.

</details>

### Documentation changes

#### Hook routing

- Clarifies that allowlisting does not change hook validation or guarantee quote compatibility.
- Adds a direction and trade-type test matrix for every relevant hook state.
- Adds multi-hop testing guidance where applicable.
- Documents safe integration options for an exact-output-only direction.
- Limits bounded inverse-search guidance to hooks that guarantee monotonic required-input quotes over a known range for a fixed state, with revalidation before execution.

#### Swap routing

- Documents the `type` field alongside `protocols` and `routingPreference`.
- Clarifies exact-input and exact-output semantics for Uniswap Protocol AMM routing.
- Clarifies that `BEST_PRICE` optimizes routes for the submitted `type` and does not reinterpret `EXACT_INPUT` as `EXACT_OUTPUT`.
- Cross-links the hook compatibility and Chained Actions guidance.

### Type of change

- [ ] Fix (typo, broken link, incorrect or outdated content)
- [ ] New content (guide, page, code example)
- [x] Update to existing content
- [ ] Other

### How has this been verified?

#### Integration and registry evidence

- [Morphogen hooklist submission and approval](https://github.com/Uniswap/hooklist/pull/1502)
- [Pinned Morphogen hook registry entry](https://github.com/Uniswap/hooklist/blob/92f38fc5b2419bdd042f18eb8a8e12f0da921b0f/hooks/robinhood/0xd27596add474e5f645cc1d2141e8ff2a3fd33aec.json)
- [Current UniRoute hook definition](https://github.com/Uniswap/uniroute-public/blob/79a83bdf2dbaf1dcd2fc6f0747585936502508bb/src/lib/poolCaching/util/hooksAddressesAllowlist.ts#L793-L796) and [Robinhood allowlist inclusion](https://github.com/Uniswap/uniroute-public/blob/79a83bdf2dbaf1dcd2fc6f0747585936502508bb/src/lib/poolCaching/util/hooksAddressesAllowlist.ts#L1252-L1259)
- [Hooklist schema](https://github.com/Uniswap/hooklist/blob/92f38fc5b2419bdd042f18eb8a8e12f0da921b0f/schema.json#L145-L177), which records `vanillaSwap` but has no direction or trade-type capability fields
- [Official hook allowlisting guidance](https://developers.uniswap.org/hook-allowlist)

#### Morphogen contract and production evidence

- [Formation-phase trade-type validation](https://github.com/wangluolingxing/morphogen-contracts/blob/1773acae436283d0412554774a9441d730eeac85/contracts/src/market/MorphogenHook.sol#L528-L565)
- [Permanent-phase trade-type validation](https://github.com/wangluolingxing/morphogen-contracts/blob/1773acae436283d0412554774a9441d730eeac85/contracts/src/market/MorphogenHook.sol#L639-L656)
- [Pinned production deployment manifest](https://github.com/wangluolingxing/morphogen-contracts/blob/1773acae436283d0412554774a9441d730eeac85/contracts/deployments/mainnet/active/robinhood.json)
- [Canonical exact-output quoter](https://github.com/wangluolingxing/morphogen-contracts/blob/1773acae436283d0412554774a9441d730eeac85/contracts/src/market/MorphogenMarketQuoter.sol#L55-L68)
- [Maximum-input and refund implementation](https://github.com/wangluolingxing/morphogen-contracts/blob/1773acae436283d0412554774a9441d730eeac85/contracts/src/market/MorphogenMarketRouter.sol#L124-L169)
- [Successful exact-output production transaction](https://robinhoodchain.blockscout.com/tx/0xb767e53706fef3b6816aa5aba3449ac9221ab6f0f3341b7d0836ceca4dc0b884)
- [Verified deployed hook](https://robinhoodchain.blockscout.com/address/0xD27596adD474e5f645Cc1D2141e8Ff2A3FD33AEC?tab=contract)

#### Uniswap request and routing evidence

- [Official Quote API exact-input/exact-output definitions](https://developers.uniswap.org/docs/api-reference/aggregator_quote)
- [Interface trade-type derivation](https://github.com/Uniswap/interface/blob/da6d36f71c4d2fd665b0aae1a052a4ffda917b31/packages/uniswap/src/features/transactions/swap/stores/swapFormStore/hooks/useDerivedSwapInfo.ts#L83-L124)
- [Interface quote-request construction](https://github.com/Uniswap/interface/blob/da6d36f71c4d2fd665b0aae1a052a4ffda917b31/packages/uniswap/src/features/transactions/swap/services/tradeService/transformations/buildQuoteRequest.ts#L82-L96)
- [UniRoute public-repository scope](https://github.com/Uniswap/uniroute-public/blob/79a83bdf2dbaf1dcd2fc6f0747585936502508bb/README.md)
- [Public UniRoute request parsing](https://github.com/Uniswap/uniroute-public/blob/79a83bdf2dbaf1dcd2fc6f0747585936502508bb/src/core/UniRouteBL.ts#L951-L963)
- [Public UniRoute quote processing](https://github.com/Uniswap/uniroute-public/blob/79a83bdf2dbaf1dcd2fc6f0747585936502508bb/src/core/UniRouteBL.ts#L1722-L1761)
- [Public UniRoute route selection](https://github.com/Uniswap/uniroute-public/blob/79a83bdf2dbaf1dcd2fc6f0747585936502508bb/src/core/UniRouteBL.ts#L1792-L1801)
- [Public UniRoute exact-mode ranking](https://github.com/Uniswap/uniroute-public/blob/79a83bdf2dbaf1dcd2fc6f0747585936502508bb/src/core/strategy/DeepQuoteStrategy.ts#L388-L395)
- [Public UniRoute trade construction](https://github.com/Uniswap/uniroute-public/blob/79a83bdf2dbaf1dcd2fc6f0747585936502508bb/src/core/UniRouteBL.ts#L3294-L3308)
- [v4 router exact-input and exact-output interfaces](https://github.com/Uniswap/v4-periphery/blob/dce236d4e2057422d0791d9a973a58765eb46f65/src/interfaces/IV4Router.sol#L30-L66)
- [v4 quoter exact-input and exact-output methods](https://github.com/Uniswap/v4-periphery/blob/dce236d4e2057422d0791d9a973a58765eb46f65/src/lens/V4Quoter.sol#L16-L88)

<details>
<summary>Additional corroborating public routing sources</summary>

- [Unified Routing API request parsing](https://github.com/Uniswap/unified-routing-api/blob/03d59252f907ca423fa4eadf5c7fea9486c91475/lib/entities/request/index.ts#L148-L155)
- [Unified Routing API quoter dispatch](https://github.com/Uniswap/unified-routing-api/blob/03d59252f907ca423fa4eadf5c7fea9486c91475/lib/providers/quoters/RoutingApiQuoter.ts#L88-L103)
- [Routing API exact-in/exact-out dispatch](https://github.com/Uniswap/routing-api/blob/f5a81893b812b6745b1f8b7fa3a55a714cb9d89b/lib/handlers/quote/quote.ts#L403-L472)
- [Smart Order Router v4 exact-in/exact-out quoter dispatch](https://github.com/Uniswap/smart-order-router/blob/04c7c0b4d85ac2a19a3ff53987d21f9c8f1fe647/src/routers/alpha-router/quoters/v4-quoter.ts#L159-L167)

</details>

#### Repository checks

- Ran `git diff --check`.
- Verified the edited MDX frontmatter, tables, and `<Callout>` structure.
- Verified every internal documentation target exists.
- Checked the pinned GitHub, Blockscout, API, and supplementary links.

The current public docs repository contains documentation content but no runnable current-site package, so validation covers the MDX structure and links rather than claiming a local full-site build.

### Scope and non-claims

- This PR does not change routing or interface behavior.
- It does not claim a Uniswap v4 core-contract failure.
- It does not claim that allowlisting guarantees route selection.
- It does not claim that every aggregator uses Uniswap's API.
- It does not prescribe inverse search for arbitrary hooks. The published guidance requires a monotonicity guarantee over a known range or hook-specific integration logic.
- It does not claim that the public UniRoute snapshot is byte-for-byte identical to every production service.

Documentation alone does not resolve the observed routing behavior. This PR intentionally limits itself to making the constraint clear for hook builders and API integrators while capability metadata or intent-translation changes are evaluated separately.

### Applicable screenshots

Not applicable to the rendered documentation change. The supplementary reports below contain the reproduced interface comparison.

### Supplementary reproduction and analysis

These reports contain the observed UI reproduction, screenshots, source trace, limitations, and longer-form analysis. The documentation change relies on the pinned primary sources above rather than these reports.

- [Part 1: When "best route" depends on how you ask](https://x.com/morphogen_/status/2092411221060505829?s=20)
- [Part 2: What Uniswap's open-source router confirms after allowlisting](https://x.com/morphogen_/status/2092521942557540499?s=20)

### Anything else reviewers should know?

The docs diff intentionally stays focused and cross-links existing pages. A routing or interface implementation change would require a separate issue or RFC with raw quote payloads and implementation-specific tests.

Implementation follow-up: [Uniswap/interface#8057](https://github.com/Uniswap/interface/issues/8057)
