### PR TITLE
fix(ci): make the AI review workflow run under pull_request_target

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,7 +30,6 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write
-  id-token: write # OIDC exchange for the Claude GitHub App token
 
 jobs:
   review:
@@ -48,6 +47,19 @@ jobs:
       - uses: anthropics/claude-code-action@1298632ce7736903d02a1435002705aa2a594a6c # v1.0.175
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # By default the action trades an OIDC token for a Claude GitHub App
+          # token, and Anthropic's exchange rejects tokens minted under
+          # `pull_request_target` (anthropics/claude-code-action#713). Passing the
+          # job token skips that exchange. Under `pull_request_target` the job
+          # token carries this workflow's declared permissions, so it can post
+          # comments. Comments appear as github-actions[bot], not claude[bot].
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # The action refuses actors without write access, and community
+          # authors never have it here. This is the documented escape hatch for
+          # exactly this shape: a job token scoped to `pull-requests: write`, the
+          # PR head never checked out, and tools limited to reading the diff and
+          # posting comments.
+          allowed_non_write_users: '*'
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -55,8 +55,9 @@ jobs:
           # comments. Comments appear as github-actions[bot], not claude[bot].
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # The action refuses actors without write access, and community
-          # authors never have it here. This is the documented escape hatch for
-          # exactly this shape: a job token scoped to `pull-requests: write`, the
+          # authors never have it here. This input is the action's escape hatch.
+          # Its docs restrict it to workflows with very limited permissions, and
+          # this one qualifies: a job token scoped to `pull-requests: write`, the
           # PR head never checked out, and tools limited to reading the diff and
           # posting comments.
           allowed_non_write_users: '*'


### PR DESCRIPTION
### Summary

The `AI review` check has failed on every PR since the workflow landed in #1139. The action trades an OIDC token for a Claude GitHub App token, and Anthropic's exchange rejects tokens minted under `pull_request_target` (see [anthropics/claude-code-action#713](https://github.com/anthropics/claude-code-action/issues/713), open since December with no fix released).

This passes the job token to the action instead, which skips the exchange entirely. It also allows non-write actors so community PRs are reviewed, since the action otherwise refuses them. `id-token: write` is dropped because nothing uses it anymore.

Comments will post as `github-actions[bot]` instead of `claude[bot]`. Nothing else about the review changes: the PR head is still never checked out, and the tools are still limited to reading the diff and posting comments.

### Type of change

- [x] Fix (typo, broken link, incorrect or outdated content)
- [ ] New content (guide, page, code example)
- [ ] Update to existing content
- [x] Other

### How has this been verified?

Read the action source at the pinned commit: when `github_token` is set, `setupGitHubToken()` returns it before any OIDC request, and `allowed_non_write_users` is the documented bypass for the write-permission check. This is also the shape the action maintainers describe for `pull_request_target` in their draft docs. `actionlint` passes on the file.

A PR that changes this workflow cannot test itself: `pull_request_target` runs the base branch's definition. The first real run is the next PR opened after this merges.

### Anything else reviewers should know?

The "Actor does not have write permissions" refusal is a separate check from the OIDC exchange. Fixing only the token would move the failure to that check for every community author, so both settings are needed together.
