### PR TITLE
docs: add SolidRPC node provider

### DIFF
--- a/content/unichain/tools/node-providers.mdx
+++ b/content/unichain/tools/node-providers.mdx
@@ -7,7 +7,7 @@ description: Discover RPC and WebSocket node providers for Unichain mainnet and 
 
 The public RPC endpoint [mainnet.unichain.org](https://mainnet.unichain.org) only supports standard `JSON-RPC` calls and should not be used in production systems.
 
-All third-party node providers listed below support `WebSocket` connections for real-time data.
+Third-party providers may offer additional method support, higher limits, archive access, or `WebSocket` connections. Check each provider's documentation for current capabilities.
 
 </Callout>
 
@@ -87,3 +87,13 @@ Get started [here](https://documentation.onfinality.io/support/getting-started)
 ### Supported networks
 - [Unichain Mainnet](https://onfinality.io/networks/unichain)
 - [Unichain Sepolia Testnet](https://onfinality.io/networks/unichain-sepolia)
+
+## SolidRPC
+
+[SolidRPC](https://solidrpc.io) provides managed EVM JSON-RPC over HTTPS for Unichain, with upstream routing, failover, monitoring, and recovery handled behind a single integration. Authenticated plans support production workloads and historical access.
+
+See the [SolidRPC documentation](https://solidrpc.io/docs) to get started.
+
+### Supported networks
+
+- [Unichain Mainnet](https://solidrpc.io/docs/networks)


### PR DESCRIPTION
### Summary

Adds SolidRPC to the Unichain node provider directory.

The entry lists authenticated HTTPS access for Unichain Mainnet, with upstream routing, failover, monitoring, and recovery handled behind a single integration.

The introductory callout was also clarified because provider capabilities vary and SolidRPC does not advertise WebSocket support.

### Type of change

- [ ] Fix (typo, broken link, incorrect or outdated content)
- [ ] New content (guide, page, code example)
- [x] Update to existing content
- [ ] Other

### How has this been verified?

- Confirmed the SolidRPC documentation and network catalog are publicly accessible
- Confirmed Unichain appears in the SolidRPC network catalog
- Ran `git diff --check`

### Applicable screenshots

Not applicable — documentation-only provider entry.

### Anything else reviewers should know?

The entry lists Unichain Mainnet only. It does not claim Unichain Sepolia, public keyless, or WebSocket support.