### PR TITLE
chore(deps): maintain Claude Code Action workflows (v1.0.217)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: anthropics/claude-code-action@1298632ce7736903d02a1435002705aa2a594a6c # v1.0.175
+      - uses: anthropics/claude-code-action@9c5ddab2e6d17b83ea679153b31f1d5f023cf636 # v1.0.217
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # By default the action trades an OIDC token for a Claude GitHub App


### PR DESCRIPTION
## Summary

Maintenance pass on Claude Code Action workflows. Applies three classes of edit atomically:

- **claude-code-action:** `v1.0.217` (`9c5ddab`) — see https://github.com/anthropics/claude-code-action/releases/tag/v1.0.217
- **ai-toolkit reusable workflows:** `c4820d6` (Uniswap/ai-toolkit `main` HEAD, the released branch)
- **Models:**
  - `haiku` → `claude-haiku-4-5-20251001`
  - `opus` → `claude-opus-5`
  - `sonnet` → `claude-sonnet-5`

### Per-file changes

#### `.github/workflows/claude-code-review.yml`
- SHA bump `anthropics/claude-code-action`: `1298632` → `9c5ddab` (v1.0.217)

---

_Opened by the `sync-claude-code-action` maintenance job. The job runs weekly and bumps SHAs + applies known migrations; review the diff before merging._