### PR TITLE
docs: add node101 to Unichain node providers

### DIFF
--- a/content/unichain/tools/node-providers.mdx
+++ b/content/unichain/tools/node-providers.mdx
@@ -70,6 +70,17 @@ See the [quickstart](https://docs.metamask.io/services/reference/unichain/) to g
 - [Unichain Mainnet](https://docs.metamask.io/services/reference/unichain/)
 - [Unichain Sepolia Testnet](https://docs.metamask.io/services/reference/unichain/)
 
+## node101
+
+[node101](https://node101.io/en/rpc/unichain) provides paid Unichain RPC services and managed dedicated nodes for developers, wallets, exchanges, and infrastructure teams. Capabilities include standard JSON-RPC, HTTP and WebSocket access, transaction tracing, Flashblocks API access, and a distributed architecture. The service includes dashboard monitoring of usage, endpoints, performance, and service status, plus incident reports and 24/7 technical support. Archive node services and testnet RPC support are available on request. Dedicated deployments can be scoped across Türkiye, Europe, and the United States.
+
+[View plans and contact node101](https://node101.io/en/rpc/unichain).
+
+### Supported networks
+
+- [Unichain Mainnet](https://node101.io/en/rpc/unichain)
+- Unichain testnet RPC support on request
+
 ## QuickNode
 
 [QuickNode](https://www.quicknode.com/chains/unichain?utm_source=unichaindocs) provides hosted Unichain RPC nodes under their free and paid plans, granting flexible and reliable access to the network. For high-throughput or mission-critical applications, [Dedicated Clusters](https://www.quicknode.com/clusters?utm_source=unichaindocs) deliver premium performance with unmetered billing, elevated rate limits, and robust infrastructure.


### PR DESCRIPTION
### Summary

Add node101 to the [Unichain Node Providers page](https://developers.uniswap.org/docs/unichain/tools/node-providers), using the existing provider paragraph and supported-networks format.

The entry covers paid JSON-RPC and dedicated nodes, HTTP/WebSocket, transaction tracing, Flashblocks API access, monitoring, incident reports, 24/7 support, archive services, and testnet RPC on request.

### Type of change

- [ ] Fix (typo, broken link, incorrect or outdated content)
- [ ] New content (guide, page, code example)
- [x] Update to existing content
- [ ] Other

### How has this been verified?

Compared the entry with the live [node101 product page](https://node101.io/en/rpc/unichain) and existing Blockdaemon/QuickNode/Dwellir entries. Only `content/unichain/tools/node-providers.mdx` changes. The patch applies cleanly to the current main branch, and the complete proposed MDX file compiles successfully with @mdx-js/mdx and remark-gfm. No live endpoint performance test or publishing preview has been run.

### Applicable screenshots

Not applicable: text-only provider entry.

### Anything else reviewers should know?

The RPC service is paid and closed-source, with testnet and archive services available on request. No free public endpoint is advertised. We understand accepted changes are ported into the separate publishing pipeline.
